### PR TITLE
Fix issue where non-string '$ref' properties were assumed to be referenc...

### DIFF
--- a/src/ZSchema.js
+++ b/src/ZSchema.js
@@ -964,7 +964,7 @@
     // recurse schema and collect all references for download
     ZSchema.prototype._collectReferences = function _collectReferences(schema) {
         var arr = [];
-        if (schema.$ref) {
+        if (Utils.isString(schema.$ref)) {
             arr.push(schema);
         }
         Utils.forEach(schema, function (val, key) {
@@ -1039,7 +1039,8 @@
         if (!schema) {
             schema = rootSchema;
         }
-        if (schema.$ref && schema.__$refResolved !== null && schema.$ref.indexOf('http:') !== 0 && schema.$ref.indexOf('https:') !== 0) {
+        if (Utils.isString(schema.$ref) && schema.__$refResolved !== null && schema.$ref.indexOf('http:') !== 0 &&
+            schema.$ref.indexOf('https:') !== 0) {
             schema.__$refResolved = Utils.resolveSchemaQuery(schema, rootSchema, schema.$ref, true, this.options.sync) || null;
         }
         Utils.forEach(schema, function (val, key) {
@@ -1058,7 +1059,7 @@
         if (Utils.isString(schema.id)) {
             scope.push(schema.id);
         }
-        if (schema.$ref && !schema.__$refResolved && !Utils.isAbsoluteUri(schema.$ref)) {
+        if (Utils.isString(schema.$ref) && !schema.__$refResolved && !Utils.isAbsoluteUri(schema.$ref)) {
             if (scope.length > 0) {
                 var s = scope.join('').split('#')[0];
                 if (schema.$ref[0] === '#') {

--- a/test/reference.js
+++ b/test/reference.js
@@ -264,4 +264,18 @@ describe('Validations for referencing children:', function () {
         });
     });
 
+    it('should not treat non-string $ref properties as references', function (done) {
+        var schema = {
+            'type': 'object',
+            'properties': {
+                '$ref': {
+                    'type': 'string'
+                }
+            }
+        };
+        var validator = new ZSchema({ sync: true });
+        validator.compileSchema(schema);
+        done();
+    });
+
 });


### PR DESCRIPTION
Prior to this patch, z-schema would assume any '$ref' property on an object was a reference.  When this happened, numerous locations would fail due to this assumption.  I updated the locations I could replicate.
