### PR TITLE
Report string error paths as a JSON Pointer

### DIFF
--- a/src/JsonValidation.js
+++ b/src/JsonValidation.js
@@ -344,13 +344,13 @@ var recurseArray = function (report, schema, json) {
         while (idx--) {
             // equal to doesnt make sense here
             if (idx < schema.items.length) {
-                report.path.push("[" + idx + "]");
+                report.path.push(idx.toString());
                 exports.validate.call(this, report, schema.items[idx], json[idx]);
                 report.path.pop();
             } else {
                 // might be boolean, so check that it's an object
                 if (typeof schema.additionalItems === "object") {
-                    report.path.push("[" + idx + "]");
+                    report.path.push(idx.toString());
                     exports.validate.call(this, report, schema.additionalItems, json[idx]);
                     report.path.pop();
                 }
@@ -362,7 +362,7 @@ var recurseArray = function (report, schema, json) {
         // If items is a schema, then the child instance must be valid against this schema,
         // regardless of its index, and regardless of the value of "additionalItems".
         while (idx--) {
-            report.path.push("[" + idx + "]");
+            report.path.push(idx.toString());
             exports.validate.call(this, report, schema.items, json[idx]);
             report.path.pop();
         }

--- a/src/Report.js
+++ b/src/Report.js
@@ -75,28 +75,18 @@ Report.prototype.processAsyncTasks = function (timeout, callback) {
 
 Report.prototype.getPath = function () {
     var path = [];
-    var response;
     if (this.parentReport) {
         path = path.concat(this.parentReport.path);
     }
     path = path.concat(this.path);
 
-    if (this.options.reportPathAsArray === true) {
-        response = [];
-        // Since path entries can have square brackets in them and we don't want them when displaying the path as an
-        // array of path segments, we need to remove them.  https://github.com/zaggino/z-schema/issues/59 would fix this
-        // as array/object indices/keys would not be surrounded by brackets to support JSON Pointer strings.
-        path.forEach(function (entry) {
-            entry.replace(/[\[\]']+/g, " ").split(" ").forEach(function (segment) {
-                if (segment) {
-                    response.push(segment);
-                }
-            });
-        });
-    } else {
-        response = "#/" + path.join("/");
+    if (this.options.reportPathAsArray !== true) {
+        // Sanitize the path segments (http://tools.ietf.org/html/rfc6901#section-4)
+        path = "#/" + path.map(function (segment) {
+            return segment.replace("~", "~0").replace("/", "~1");
+        }).join("/");
     }
-    return response;
+    return path;
 };
 
 Report.prototype.addError = function (errorCode, params, subReports, schemaDescription) {

--- a/src/SchemaValidation.js
+++ b/src/SchemaValidation.js
@@ -105,8 +105,10 @@ var SchemaValidators = {
         } else if (type === "array") {
             var idx = schema.items.length;
             while (idx--) {
-                report.path.push("items[" + idx + "]");
+                report.path.push("items");
+                report.path.push(idx.toString());
                 exports.validateSchema.call(this, report, schema.items[idx]);
+                report.path.pop();
                 report.path.pop();
             }
         } else {
@@ -201,8 +203,10 @@ var SchemaValidators = {
         while (idx--) {
             var key = keys[idx],
                 val = schema.properties[key];
-            report.path.push("properties[" + key + "]");
+            report.path.push("properties");
+            report.path.push(key);
             exports.validateSchema.call(this, report, val);
+            report.path.pop();
             report.path.pop();
         }
 
@@ -236,8 +240,10 @@ var SchemaValidators = {
             } catch (e) {
                 report.addError("KEYWORD_PATTERN", ["patternProperties", key]);
             }
-            report.path.push("patternProperties[" + key + "]");
+            report.path.push("patternProperties");
+            report.path.push(key.toString());
             exports.validateSchema.call(this, report, val);
+            report.path.pop();
             report.path.pop();
         }
 
@@ -259,8 +265,10 @@ var SchemaValidators = {
                     type = Utils.whatIs(schemaDependency);
 
                 if (type === "object") {
-                    report.path.push("dependencies[" + schemaKey + "]");
+                    report.path.push("dependencies");
+                    report.path.push(schemaKey);
                     exports.validateSchema.call(this, report, schemaDependency);
+                    report.path.pop();
                     report.path.pop();
                 } else if (type === "array") {
                     var idx2 = schemaDependency.length;
@@ -360,8 +368,10 @@ var SchemaValidators = {
         } else {
             var idx = schema.allOf.length;
             while (idx--) {
-                report.path.push("allOf[" + idx + "]");
+                report.path.push("allOf");
+                report.path.push(idx.toString());
                 exports.validateSchema.call(this, report, schema.allOf[idx]);
+                report.path.pop();
                 report.path.pop();
             }
         }
@@ -375,8 +385,10 @@ var SchemaValidators = {
         } else {
             var idx = schema.anyOf.length;
             while (idx--) {
-                report.path.push("anyOf[" + idx + "]");
+                report.path.push("anyOf");
+                report.path.push(idx.toString());
                 exports.validateSchema.call(this, report, schema.anyOf[idx]);
+                report.path.pop();
                 report.path.pop();
             }
         }
@@ -390,8 +402,10 @@ var SchemaValidators = {
         } else {
             var idx = schema.oneOf.length;
             while (idx--) {
-                report.path.push("oneOf[" + idx + "]");
+                report.path.push("oneOf");
+                report.path.push(idx.toString());
                 exports.validateSchema.call(this, report, schema.oneOf[idx]);
+                report.path.pop();
                 report.path.pop();
             }
         }
@@ -416,8 +430,10 @@ var SchemaValidators = {
             while (idx--) {
                 var key = keys[idx],
                     val = schema.definitions[key];
-                report.path.push("definitions[" + key + "]");
+                report.path.push("definitions");
+                report.path.push(key);
                 exports.validateSchema.call(this, report, val);
+                report.path.pop();
                 report.path.pop();
             }
         }

--- a/test/ZSchemaTestSuite/ErrorPathAsJSONPointer.js
+++ b/test/ZSchemaTestSuite/ErrorPathAsJSONPointer.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = {
+    description: "Report error paths as a JSON Pointer string",
+    tests: [
+        {
+            description: "should fail validation and report error paths a JSON Pointer string",
+            schema: {
+                "type": "object",
+                "properties": {
+                  "~name/age": {
+                    "type": "invalid"
+                  }
+                }
+            },
+            valid: false,
+            validateSchemaOnly: true,
+            after: function (err) {
+                expect(err[0].path).toEqual("#/properties/~0name~1age");
+            }
+        }
+    ]
+};

--- a/test/spec/ZSchemaTestSuiteSpec.js
+++ b/test/spec/ZSchemaTestSuiteSpec.js
@@ -20,6 +20,7 @@ var testSuiteFiles = [
     require("../ZSchemaTestSuite/StrictUris.js"),
     require("../ZSchemaTestSuite/MultipleSchemas.js"),
     require("../ZSchemaTestSuite/ErrorPathAsArray.js"),
+    require("../ZSchemaTestSuite/ErrorPathAsJSONPointer.js"),
     // issues
     require("../ZSchemaTestSuite/Issue12.js"),
     require("../ZSchemaTestSuite/Issue13.js"),
@@ -52,8 +53,8 @@ describe("ZSchemaTestSuite", function () {
         }
     }
 
-    it("should contain 34 files", function () {
-        expect(testSuiteFiles.length).toBe(34);
+    it("should contain 35 files", function () {
+        expect(testSuiteFiles.length).toBe(35);
     });
 
     testSuiteFiles.forEach(function (testSuite) {


### PR DESCRIPTION
Whenever error paths are strings, the default, report them as a JSON Pointer.

Fixes #59 
