### PR TITLE
additionalProperties problem

### DIFF
--- a/test/ZSchemaTestSuite/Issue71.js
+++ b/test/ZSchemaTestSuite/Issue71.js
@@ -1,0 +1,58 @@
+"use strict";
+
+module.exports = {
+    description: "Issue #71 - additionalProperties problem",
+    tests: [
+        {
+            description: "should have two errors",
+
+            schema: {
+                type: 'object',
+                minProperties: 1,
+                additionalProperties: false,
+                properties: {
+                    foo: {
+                        type: 'object',
+                        minProperties: 1
+                    }
+                }
+            },
+
+            data: { foo: {}, bar: 1 },
+
+            valid: false,
+
+            after: function(errors) {
+                expect(errors.length).toBe(2);
+            }
+        },
+
+        {
+            description: "should have two errors",
+
+            schema: {
+                type: 'object',
+                minProperties: 1,
+                additionalProperties: false,
+                properties: {
+                    foo: {
+                        type: 'object',
+                        minProperties: 1,
+                        additionalProperties: false,
+                        properties: {
+                            foo: {}
+                        }
+                    }
+                }
+            },
+
+            data: { foo: {}, bar: 1 },
+
+            valid: false,
+
+            after: function(errors) {
+                expect(errors.length).toBe(2);
+            }
+        }
+    ]
+};

--- a/test/spec/ZSchemaTestSuiteSpec.js
+++ b/test/spec/ZSchemaTestSuiteSpec.js
@@ -44,6 +44,7 @@ var testSuiteFiles = [
     require("../ZSchemaTestSuite/Issue63.js"),
     require("../ZSchemaTestSuite/Issue64.js"),
     require("../ZSchemaTestSuite/Issue67.js"),
+    require("../ZSchemaTestSuite/Issue71.js"),
     undefined
 ];
 
@@ -56,8 +57,8 @@ describe("ZSchemaTestSuite", function () {
         }
     }
 
-    it("should contain 38 files", function () {
-        expect(testSuiteFiles.length).toBe(38);
+    it("should contain 39 files", function () {
+        expect(testSuiteFiles.length).toBe(39);
     });
 
     testSuiteFiles.forEach(function (testSuite) {


### PR DESCRIPTION
Hi! It is the best JSON validator I have tried. :-) Thanks for your job.

I found some strange behaviour and wrote the test case in PR.
When I add `aditionalProperties` and `properties` fields in schema, some errors after validation disappears.

UPD: 
In the first test I have `OBJECT_ADDITIONAL_PROPERTIES` and `OBJECT_PROPERTIES_MINIMUM` errors. But there is only one error `OBJECT_ADDITIONAL_PROPERTIES` in the second.
