### PR TITLE
handle circular references when deep cloing and resolving $ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   "dependencies": {
     "commander": "^2.7.1",
     "request": "^2.54.0",
-    "validator": "^3.35.0",
-    "clone": "~1.0.2"
+    "validator": "^3.35.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "commander": "^2.7.1",
     "request": "^2.54.0",
-    "validator": "^3.35.0"
+    "validator": "^3.35.0",
+    "clone": "~1.0.2"
   }
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var cloneDeep = require('clone');
+
 exports.isAbsoluteUri = function (uri) {
     return /^https?:\/\//.test(uri);
 };
@@ -138,26 +140,7 @@ exports.clone = function (src) {
     return res;
 };
 
-exports.cloneDeep = function cloneDeep(src) {
-    if (typeof src !== "object" || src === null) { return src; }
-    var res, idx;
-    if (Array.isArray(src)) {
-        res = [];
-        idx = src.length;
-        while (idx--) {
-            res[idx] = cloneDeep(src[idx]);
-        }
-    } else {
-        res = {};
-        var keys = Object.keys(src);
-        idx = keys.length;
-        while (idx--) {
-            var key = keys[idx];
-            res[key] = cloneDeep(src[key]);
-        }
-    }
-    return res;
-};
+exports.cloneDeep = cloneDeep;
 
 /*
   following function comes from punycode.js library

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var cloneDeep = require('clone');
 
 exports.isAbsoluteUri = function (uri) {
     return /^https?:\/\//.test(uri);
@@ -140,7 +139,37 @@ exports.clone = function (src) {
     return res;
 };
 
-exports.cloneDeep = cloneDeep;
+exports.cloneDeep = function (src) {
+    var visited = [], cloned = [];
+    function cloneDeep(src) {
+        if (typeof src !== "object" || src === null) { return src; }
+        var res, idx, cidx;
+
+        cidx = visited.indexOf(src);
+        if (cidx !== -1) { return cloned[cidx]; }
+
+        visited.push(src);
+        if (Array.isArray(src)) {
+            res = [];
+            cloned.push(res);
+            idx = src.length;
+            while (idx--) {
+                res[idx] = cloneDeep(src[idx]);
+            }
+        } else {
+            res = {};
+            cloned.push(res);
+            var keys = Object.keys(src);
+            idx = keys.length;
+            while (idx--) {
+                var key = keys[idx];
+                res[key] = cloneDeep(src[key]);
+            }
+        }
+        return res;
+    }
+    return cloneDeep(src);
+};
 
 /*
   following function comes from punycode.js library


### PR DESCRIPTION
In version 3.9.2, this enters into an infinite loop...
```js
(new ZSchema()).getResolvedSchema("http://json-schema.org/draft-04/schema#")
```