### PR TITLE
Handle incorrect id keyword

### DIFF
--- a/src/SchemaCompilation.js
+++ b/src/SchemaCompilation.js
@@ -199,7 +199,7 @@ exports.compileSchema = function (report, schema) {
         return true;
     }
 
-    if (schema.id) {
+    if (schema.id && typeof schema.id === 'string') {
         // add this to our schemaCache (before compilation in case we have references including id)
         SchemaCache.cacheSchemaByUri.call(this, schema.id, schema);
     }
@@ -276,7 +276,7 @@ exports.compileSchema = function (report, schema) {
     if (isValid) {
         schema.__$compiled = true;
     } else {
-        if (schema.id) {
+        if (schema.id && typeof schema.id === 'string') {
             // remove this schema from schemaCache because it failed to compile
             SchemaCache.removeFromCacheByUri.call(this, schema.id);
         }

--- a/test/ZSchemaTestSuite/InvalidId.js
+++ b/test/ZSchemaTestSuite/InvalidId.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = {
+    description: "InvalidId - check if schema with invalid id can be processed",
+    validateSchemaOnly: true,
+    tests: [
+        {
+            schema: {
+                "id": {}
+            },
+            description: "should fail schema validation because id has incorrect value",
+            valid: false
+        }
+    ]
+};

--- a/test/spec/ZSchemaTestSuiteSpec.js
+++ b/test/spec/ZSchemaTestSuiteSpec.js
@@ -26,6 +26,7 @@ var testSuiteFiles = [
     require("../ZSchemaTestSuite/ErrorPathAsJSONPointer.js"),
     require("../ZSchemaTestSuite/PedanticCheck.js"),
     require("../ZSchemaTestSuite/getRegisteredFormats.js"),
+    require("../ZSchemaTestSuite/InvalidId.js"),
     // issues
     require("../ZSchemaTestSuite/Issue12.js"),
     require("../ZSchemaTestSuite/Issue13.js"),
@@ -80,8 +81,8 @@ describe("ZSchemaTestSuite", function () {
         }
     }
 
-    it("should contain 61 files", function () {
-        expect(testSuiteFiles.length).toBe(61);
+    it("should contain 62 files", function () {
+        expect(testSuiteFiles.length).toBe(62);
     });
 
     testSuiteFiles.forEach(function (testSuite) {


### PR DESCRIPTION
Before changes crushed with following error:
>TypeError: undefined is not a function
    at getRemotePath (/home/ivang/dev/z-schema/src/SchemaCache.js:9:791)
    at ZSchema.exports.cacheSchemaByUri (/home/ivang/dev/z-schema/src/SchemaCache.js:9:3845)
    at ZSchema.exports.compileSchema (/home/ivang/dev/z-schema/src/SchemaCompilation.js:9:10539)
    at ZSchema.validateSchema (/home/ivang/dev/z-schema/src/ZSchema.js:9:5031)
    at null.<anonymous> (/home/ivang/dev/z-schema/test/spec/ZSchemaTestSuiteSpec.js:115:39)