### PR TITLE
Add Node v4/v5 to travis.yml, update from legacy infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"
+  - "4"
+  - "5"
+sudo: false
 before_install:
   - npm install -g grunt-cli
 after_script:


### PR DESCRIPTION
Add more recent Node.js versions to the Travis CI build matrix and include `sudo: false` to migrate away from their legacy infrastructure.