### PR TITLE
Do not duplicate same schema of different instance in cache.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "lodash.get": "^4.1.2",
+    "lodash.isequal": "^4.4.0",
     "validator": "^5.0.0"
   },
   "optionalDependencies": {

--- a/src/SchemaCache.js
+++ b/src/SchemaCache.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var isequal             = require("lodash.isequal");
 var Report              = require("./Report");
 var SchemaCompilation   = require("./SchemaCompilation");
 var SchemaValidation    = require("./SchemaValidation");
@@ -95,7 +96,7 @@ exports.getSchema = function (report, schema) {
 exports.getSchemaByReference = function (report, key) {
     var i = this.referenceCache.length;
     while (i--) {
-        if (this.referenceCache[i][0] === key) {
+        if (isequal(this.referenceCache[i][0], key)) {
             return this.referenceCache[i][1];
         }
     }


### PR DESCRIPTION
In my company we noticed a major memory leak in one of our node server based on 
https://github.com/theganyo/swagger-node-runner & https://github.com/apigee-127/sway

In swagger-node-runner the same JSON-schema is given as a different object instance at each request.
(Which makes sens to insure request isolation).

Then every request get added to the SchemaCache.. which eventually explode the server memory.

This commit address this issue.

Cheers