### PR TITLE
Upgrade to latest validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "lodash.get": "^4.1.2",
     "lodash.isequal": "^4.4.0",
-    "validator": "^5.0.0"
+    "validator": "^6.0.0"
   },
   "optionalDependencies": {
     "commander": "^2.7.1"


### PR DESCRIPTION
The only breaking change in the 6.x branch of `validator` is:

> Renamed isNull() to isEmpty()

[See…](https://github.com/chriso/validator.js/blob/master/CHANGELOG.md#600)