### PR TITLE
[wip] use Map if available for the referenceCache

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -34,6 +34,7 @@
         "describe": true,
         "it": true,
         "expect": true,
-        "beforeEach": true
+        "beforeEach": true,
+        "Map": true
     }
 }

--- a/src/ReferenceCache.js
+++ b/src/ReferenceCache.js
@@ -1,0 +1,34 @@
+var isequal = require("lodash.isequal");
+
+function ReferenceCache() {
+    this.init();
+}
+
+if (typeof Map !== "undefined") {
+    ReferenceCache.prototype = {
+        init: function() { this.map = new Map(); },
+        set: function(key, value) {
+            this.map.set(key, value);
+        },
+        get: function(key) {
+            return this.map.get(key);
+        }
+    };
+} else {
+    ReferenceCache.prototype = {
+        init: function() { this.map = []; },
+        set: function(key, value) {
+            this.map.push([key, value]);
+        },
+        get: function(key) {
+            var i = this.map.length;
+            while (i--) {
+                if (isequal(this.map[i][0], key)) {
+                    return this.map[i][1];
+                }
+            }
+        }
+    };
+}
+
+module.exports = ReferenceCache;

--- a/src/SchemaCache.js
+++ b/src/SchemaCache.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var isequal             = require("lodash.isequal");
 var Report              = require("./Report");
 var SchemaCompilation   = require("./SchemaCompilation");
 var SchemaValidation    = require("./SchemaValidation");
@@ -94,15 +93,11 @@ exports.getSchema = function (report, schema) {
 };
 
 exports.getSchemaByReference = function (report, key) {
-    var i = this.referenceCache.length;
-    while (i--) {
-        if (isequal(this.referenceCache[i][0], key)) {
-            return this.referenceCache[i][1];
-        }
-    }
+    var fromCache = this.referenceCache.get(key);
+    if (fromCache) { return fromCache; }
     // not found
     var schema = Utils.cloneDeep(key);
-    this.referenceCache.push([key, schema]);
+    this.referenceCache.set(key, schema);
     return schema;
 };
 

--- a/src/ZSchema.js
+++ b/src/ZSchema.js
@@ -11,7 +11,7 @@ var SchemaValidation  = require("./SchemaValidation");
 var Utils             = require("./Utils");
 var Draft4Schema      = require("./schemas/schema.json");
 var Draft4HyperSchema = require("./schemas/hyper-schema.json");
-
+var ReferenceCache    = require("./ReferenceCache");
 /*
     default options
 */
@@ -65,7 +65,7 @@ var defaultOptions = {
 */
 function ZSchema(options) {
     this.cache = {};
-    this.referenceCache = [];
+    this.referenceCache = new ReferenceCache();
 
     this.setRemoteReference("http://json-schema.org/draft-04/schema", Draft4Schema);
     this.setRemoteReference("http://json-schema.org/draft-04/hyper-schema", Draft4HyperSchema);


### PR DESCRIPTION
I think the `referenceCache` is suboptimal as it is currently. It is an O(N) operation, the more schemas you have the worse it gets. We can take advantage of [ES6's Map](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Map) if available.

Not only is an O(N) but also the comparison in the for loop is using [_.isEqual](https://lodash.com/docs#isEqual) which performs a deep comparison of the schema. I assume the `isEqual` comparison is to avoid leaking references when using an schema defined in-line with the validation like in this case:

```
validator.validate(obj, { type: 'string', format: 'uri' });
```

and that's the reason this PR is WIP. I am not sure how to fix that, the current map implementation doesn't will leak references as the previous version of this library. Thoughts?