### PR TITLE
Fixed issue #209 - async validator does not return correct path

### DIFF
--- a/src/JsonValidation.js
+++ b/src/JsonValidation.js
@@ -450,7 +450,10 @@ var recurseObject = function (report, schema, json) {
         while (idx2--) {
             report.path.push(m);
             exports.validate.call(this, report, s[idx2], propertyValue);
-            report.path.pop();
+
+            // commented out to resolve issue #209 - the path gets popped before async tasks complete
+            // all the tests run fine without, there seems to be no reason to have this pop here
+            // report.path.pop();
         }
     }
 };

--- a/test/ZSchemaTestSuite/Issue209.js
+++ b/test/ZSchemaTestSuite/Issue209.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const testAsync = true;
+
+module.exports = {
+  description: "Issue #209 - async validator returns wrong path",
+  async: true,
+  options: {
+    asyncTimeout: 2000
+  },
+  setup: function (validator, Class) {
+    if (testAsync) {
+      // asynchronous validator
+      Class.registerFormat("string-length", function (str, callback) {
+        setTimeout(function () {
+          callback(str.length > 10);
+        }, 1);
+      });
+    } else {
+      // same as above but synchronous (comment out the validator above and try with this instead)
+      Class.registerFormat("string-length", function (str) {
+        return str.length > 10;
+      });
+    }
+  },
+  schema: {
+    description: "Some schema",
+    type: "object",
+    properties: {
+      userId: {
+        type: "string",
+        format: "string-length"
+      }
+    },
+    required: ["userId"]
+  },
+  tests: [
+    {
+      description: "Wrong path in custom format async validator",
+      data: { userId: "1" },
+      valid: false,
+      after: function (err) {
+        expect(err[0].path).toEqual("#/userId");
+      }
+    }
+  ]
+};

--- a/test/spec/ZSchemaTestSuiteSpec.js
+++ b/test/spec/ZSchemaTestSuiteSpec.js
@@ -73,6 +73,7 @@ var testSuiteFiles = [
     require("../ZSchemaTestSuite/Issue142.js"),
     require("../ZSchemaTestSuite/Issue146.js"),
     require("../ZSchemaTestSuite/Issue151.js"),
+    require("../ZSchemaTestSuite/Issue209.js"),
     require("../ZSchemaTestSuite/Issue222.js"),
 
     undefined
@@ -87,8 +88,8 @@ describe("ZSchemaTestSuite", function () {
         }
     }
 
-    it("should contain 68 files", function () {
-        expect(testSuiteFiles.length).toBe(68);
+    it("should contain 69 files", function () {
+        expect(testSuiteFiles.length).toBe(69);
     });
 
     testSuiteFiles.forEach(function (testSuite) {


### PR DESCRIPTION
Fixed the issue #209 with async validators not returning correct path.

It was caused by `report.path.pop();` running synchronously so by the time the async tasks complete, the path has already been removed.

I just commented the line out and all the other tests kept running fine so the line seems to be unnecessary.

Also added the unit test made by @sylar107.