### PR TITLE
Update JsonValidation.js

### DIFF
--- a/src/JsonValidation.js
+++ b/src/JsonValidation.js
@@ -21,7 +21,9 @@ var JsonValidators = {
             return;
         }
 
-        if (Utils.whatIs(json / schema.multipleOf) !== "integer") {
+        var stringMultipleOf = String(schema.multipleOf);
+        var scale = Math.pow(10, stringMultipleOf.length - stringMultipleOf.indexOf(".") - 1);
+        if (Utils.whatIs((json * scale) / (schema.multipleOf * scale)) !== "integer") {
             report.addError("MULTIPLE_OF", [json, schema.multipleOf], null, schema);
         }
     },


### PR DESCRIPTION
Floating point precision is lost:
"json / schema.multipleOf" => 20.29 / 0.01 = 2028.9999999999998 => not a "integer"