### PR TITLE
passing null instead of undefined when no error present

### DIFF
--- a/src/Report.js
+++ b/src/Report.js
@@ -81,7 +81,7 @@ Report.prototype.processAsyncTasks = function (timeout, callback) {
     function finish() {
         process.nextTick(function () {
             var valid = self.errors.length === 0,
-                err = valid ? undefined : self.errors;
+                err = valid ? null : self.errors;
             callback(err, valid);
         });
     }

--- a/src/ZSchema.js
+++ b/src/ZSchema.js
@@ -264,7 +264,7 @@ ZSchema.prototype.getLastError = function () {
     return e;
 };
 ZSchema.prototype.getLastErrors = function () {
-    return this.lastReport && this.lastReport.errors.length > 0 ? this.lastReport.errors : undefined;
+    return this.lastReport && this.lastReport.errors.length > 0 ? this.lastReport.errors : null;
 };
 ZSchema.prototype.getMissingReferences = function (arr) {
     arr = arr || this.lastReport.errors;

--- a/test/spec/AutomaticSchemaLoadingSpec.js
+++ b/test/spec/AutomaticSchemaLoadingSpec.js
@@ -61,7 +61,7 @@ describe("Automatic schema loading", function () {
 
         validateWithAutomaticDownloads(validator, data, schema, function (err, valid) {
             expect(valid).toBe(true);
-            expect(err).toBe(undefined);
+            expect(err).toBe(null);
             done();
         });
 

--- a/test/spec/ZSchemaTestSuiteSpec.js
+++ b/test/spec/ZSchemaTestSuiteSpec.js
@@ -163,7 +163,7 @@ describe("ZSchemaTestSuite", function () {
                 }
 
                 if (test.valid === true) {
-                    expect(err).toBe(undefined, "errors are not undefined when test is valid");
+                    expect(err).toBe(null, "errors are not undefined when test is valid");
                 }
 
                 if (after) {
@@ -186,7 +186,7 @@ describe("ZSchemaTestSuite", function () {
                     expect(typeof valid).toBe("boolean", "returned response is not a boolean");
                     expect(valid).toBe(test.valid, "test result doesn't match expected test result");
                     if (test.valid === true) {
-                        expect(err).toBe(undefined, "errors are not undefined when test is valid");
+                        expect(err).toBe(null, "errors are not undefined when test is valid");
                     }
                     if (after) {
                         after(err, valid, data);


### PR DESCRIPTION
no error as `null` is consistent with the error callback conventions described in the node.js knowledge-base: https://nodejs.org/en/knowledge/errors/what-are-the-error-conventions/