### PR TITLE
defaulting ignoreUnresolvableReferences to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,8 @@ var validator = new ZSchema({
 
 ## ignoreUnresolvableReferences
 
-When true, validator doesn't end with error when a remote reference is unreachable. **This setting is not recommended in production outside of testing.**
+default: `true`<br />
+When true, validator doesn't end with error when a remote reference is unreachable.
 
 ```javascript
 var validator = new ZSchema({

--- a/src/ZSchema.js
+++ b/src/ZSchema.js
@@ -37,7 +37,7 @@ var defaultOptions = {
     // force properties or patternProperties to be defined on "object" types
     forceProperties: false,
     // ignore references that cannot be resolved (remote schemas) // TODO: make sure this is only for remote schemas, not local ones
-    ignoreUnresolvableReferences: false,
+    ignoreUnresolvableReferences: true,
     // disallow usage of keywords that this validator can't handle
     noExtraKeywords: false,
     // disallow usage of schema's without "type" defined


### PR DESCRIPTION
This seems like a more sensible default. Should be published with the next major release since it is a breaking change to any dependent that doesn't explicitly set this config value.