### PR TITLE
feat: make package ESM-first via "type": "module"

### DIFF
--- a/bin/z-schema
+++ b/bin/z-schema
@@ -8,7 +8,7 @@ import path from 'path';
 import { program } from 'commander';
 import { request } from 'https';
 import pkg from '../package.json' with { type: 'json' };
-import ZSchema from '../dist/index.mjs';
+import ZSchema from '../dist/index.js';
 
 program
   .version(pkg.version)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,13 +117,13 @@ When a schema is looked up by URI, the instance cache is checked first. If not f
 
 ## Build Outputs
 
-| Output  | Format                          | Entry                        |
-| ------- | ------------------------------- | ---------------------------- |
-| `dist/` | ESM (`.mjs`) + types (`.d.mts`) | `src/index.ts` via tsdown    |
-| `cjs/`  | CommonJS                        | `src/index.ts` via tsdown    |
-| `umd/`  | UMD (browser global `ZSchema`)  | `src/z-schema.ts` via tsdown |
+| Output  | Format                         | Entry                        |
+| ------- | ------------------------------ | ---------------------------- |
+| `dist/` | ESM (`.js`) + types (`.d.ts`)  | `src/index.ts` via tsdown    |
+| `cjs/`  | CommonJS (`.cjs` + `.d.cts`)   | `src/index.ts` via tsdown    |
+| `umd/`  | UMD (browser global `ZSchema`) | `src/z-schema.ts` via tsdown |
 
-All outputs are produced by [tsdown](https://tsdown.dev/) (powered by Rolldown). ESM output uses `.mjs` extensions; the `package.json` exports map uses conditional `import`/`require` to route consumers to the correct format.
+The package is ESM-first (`"type": "module"`), so all outputs are produced by [tsdown](https://tsdown.dev/) (powered by Rolldown) with type-appropriate extensions: ESM uses `.js`, CommonJS uses `.cjs` (with a `umd/package.json` `{"type":"commonjs"}` marker so the UMD bundles remain CommonJS for Node `require`). The `package.json` exports map uses conditional `import`/`require` to route consumers to the correct format.
 
 ## Key Internal Types
 

--- a/package.json
+++ b/package.json
@@ -39,20 +39,21 @@
     "LICENSE",
     "README.md"
   ],
+  "type": "module",
   "sideEffects": [
-    "./dist/z-schema-versions.mjs"
+    "./dist/z-schema-versions.js"
   ],
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       },
       "require": {
-        "types": "./cjs/index.d.ts",
-        "default": "./cjs/index.js"
+        "types": "./cjs/index.d.cts",
+        "default": "./cjs/index.cjs"
       },
-      "default": "./dist/index.mjs"
+      "default": "./dist/index.js"
     }
   },
   "scripts": {
@@ -63,7 +64,7 @@
     "lint": "oxlint -c oxlint.config.mjs --fix",
     "lint:check": "oxlint -c oxlint.config.mjs",
     "clean": "rimraf ./cjs && rimraf ./dist && rimraf ./umd && rimraf --glob \"./src/schemas/*.json\"",
-    "build": "npm run copy:schemas && tsdown",
+    "build": "npm run copy:schemas && tsdown && node ./scripts/write-build-markers.mts",
     "build:watch": "npm run copy:schemas && tsdown --watch",
     "build:tests": "tsc --noEmit --project test/tsconfig.json",
     "copy:schemas": "node ./scripts/copy-schemas.mts",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lint": "oxlint -c oxlint.config.mjs --fix",
     "lint:check": "oxlint -c oxlint.config.mjs",
     "clean": "rimraf ./cjs && rimraf ./dist && rimraf ./umd && rimraf --glob \"./src/schemas/*.json\"",
-    "build": "npm run copy:schemas && tsdown && node ./scripts/write-build-markers.mts",
+    "build": "npm run copy:schemas && tsdown && node ./scripts/write-build-markers.mjs",
     "build:watch": "npm run copy:schemas && tsdown --watch",
     "build:tests": "tsc --noEmit --project test/tsconfig.json",
     "copy:schemas": "node ./scripts/copy-schemas.mts",

--- a/scripts/write-build-markers.mjs
+++ b/scripts/write-build-markers.mjs
@@ -8,7 +8,11 @@
 // `umd/package.json` with `{"type":"commonjs"}` keeps the UMD bundles CommonJS
 // for Node consumers (browser `<script>` usage is unaffected either way).
 //
-// This runs after tsdown, which cleans `umd/` on each build.
+// This runs after tsdown, which cleans `umd/` on each build. Authored as plain
+// `.mjs` (no TypeScript syntax) so it runs on any supported Node version.
 import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-writeFileSync('umd/package.json', `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`);
+const umdPackageJson = join(import.meta.dirname, '..', 'umd', 'package.json');
+
+writeFileSync(umdPackageJson, `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`);

--- a/scripts/write-build-markers.mts
+++ b/scripts/write-build-markers.mts
@@ -1,0 +1,14 @@
+// Post-build step: mark the UMD output directory as CommonJS.
+//
+// The package root declares `"type": "module"`, so every `.js` file in the
+// package is treated as ESM by Node. The `dist/` output is ESM (`.js`) and the
+// `cjs/` output uses the self-describing `.cjs` extension, but the UMD bundles
+// are emitted as `umd/*.js`. Without an explicit marker, Node would interpret
+// them as ESM and `require('z-schema/umd/ZSchema.js')` would break. Writing a
+// `umd/package.json` with `{"type":"commonjs"}` keeps the UMD bundles CommonJS
+// for Node consumers (browser `<script>` usage is unaffected either way).
+//
+// This runs after tsdown, which cleans `umd/` on each build.
+import { writeFileSync } from 'node:fs';
+
+writeFileSync('umd/package.json', `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`);

--- a/test/spec/build-artifacts.node-spec.ts
+++ b/test/spec/build-artifacts.node-spec.ts
@@ -2,13 +2,13 @@ import fs from 'fs';
 
 describe('Build artifacts', function () {
   it('creates ESM output', function () {
-    expect(fs.existsSync('dist/index.mjs')).toBe(true);
-    expect(fs.existsSync('dist/index.d.mts')).toBe(true);
+    expect(fs.existsSync('dist/index.js')).toBe(true);
+    expect(fs.existsSync('dist/index.d.ts')).toBe(true);
   });
 
   it('creates CJS bundle', function () {
-    expect(fs.existsSync('cjs/index.js')).toBe(true);
-    expect(fs.existsSync('cjs/index.d.ts')).toBe(true);
+    expect(fs.existsSync('cjs/index.cjs')).toBe(true);
+    expect(fs.existsSync('cjs/index.d.cts')).toBe(true);
   });
 
   it('creates UMD bundles', function () {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ export default defineConfig([
     clean: true,
     platform: 'neutral',
   },
-  // 2. CJS — bundled into cjs/index.js + cjs/index.d.ts
+  // 2. CJS — bundled into cjs/index.cjs + cjs/index.d.cts
   {
     entry: ['src/index.ts'],
     format: ['cjs'],


### PR DESCRIPTION
## What

Declares `"type": "module"` at the package root, making z-schema ESM-first. tsdown adapts its output extensions to the package type:

| Output | Before | After |
|---|---|---|
| ESM (`dist/`) | `index.mjs` / `index.d.mts` | `index.js` / `index.d.ts` |
| CJS (`cjs/`) | `index.js` / `index.d.ts` | `index.cjs` / `index.d.cts` |
| UMD (`umd/`) | `ZSchema.js` | `ZSchema.js` (+ generated `umd/package.json`) |

Updated to match: the `exports` map, `sideEffects`, the `bin/z-schema` dist import, the `build-artifacts` test, `tsdown.config.ts` comment, and `docs/architecture.md`.

A post-build step (`scripts/write-build-markers.mts`) writes `umd/package.json` `{"type":"commonjs"}` so the UMD bundles remain CommonJS for Node `require()` under the ESM-first root (`umd/` is cleaned on each build, so the marker is generated, not committed).

## Compatibility

- **Public exports contract preserved.** `import 'z-schema'` and `require('z-schema')` both resolve via the `exports` map — verified loading the rebuilt CJS, ESM, and UMD artifacts. README/usage/MIGRATION examples use package-name imports and are unaffected.
- **Breaking only for** consumers deep-importing the old filenames directly (`z-schema/dist/index.mjs`, `z-schema/cjs/index.js`) — not a documented entry point.
- `bin/z-schema` (already ESM-authored) now runs as explicit ESM rather than relying on Node's module-syntax auto-detection.

## Verification

- `npm run build` → correct outputs; CJS `require`, ESM `import`, UMD `require`, and `bin/z-schema --version` all work
- `npm run lint:check` (0 errors), `npm run format:check` (clean), `npm run build:tests` (pass)
- Tests: **8,116 node + 24,273 browser**, 0 failures (incl. updated `build-artifacts`)

`feat:` is intentional so release-please raises a minor version.