### PR TITLE
test: fix npm run check warnings

### DIFF
--- a/test/spec/async-validation-example.spec.ts
+++ b/test/spec/async-validation-example.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { ValidateError } from '../../src/index.ts';
 import { ZSchema } from '../../src/z-schema.ts';
 
 describe('Async Validation Example', () => {
@@ -330,7 +331,7 @@ describe('Async Validation Example', () => {
         },
       };
 
-      await expect(validator.validate(invalidPayload, personSchema)).rejects.toThrow();
+      await expect(validator.validate(invalidPayload, personSchema)).rejects.toThrow(ValidateError);
     });
 
     it('should handle async validation with Promise API', async () => {

--- a/test/spec/lib-init-and-usage.spec.ts
+++ b/test/spec/lib-init-and-usage.spec.ts
@@ -1,11 +1,12 @@
 import type { ZSchemaAsync, ZSchemaAsyncSafe, ZSchemaSafe } from '../../src/z-schema.ts';
 
+import { ValidateError } from '../../src/index.ts';
 import { ZSchema } from '../../src/z-schema.ts';
 
 describe('Initialization and usage', function () {
   it('Should not allow to use new', function () {
     // @ts-expect-error: intentionally testing that private constructor throws at runtime
-    expect(() => new ZSchema()).toThrow();
+    expect(() => new ZSchema()).toThrow('do not use new ZSchema()');
   });
 
   it('Should construct validator from factory', async function () {
@@ -14,7 +15,7 @@ describe('Initialization and usage', function () {
     // validate - should return true for valid
     expect(validator.validate(1, { type: 'number' })).toBe(true);
     // validate - should throw for invalid
-    expect(() => validator.validate('not-a-number', { type: 'number' })).toThrow();
+    expect(() => validator.validate('not-a-number', { type: 'number' })).toThrow('JSON_OBJECT_VALIDATION_FAILED');
 
     // validateSafe - should return true for valid
     expect(validator.validateSafe(1, { type: 'number' }).valid).toBe(true);
@@ -24,7 +25,7 @@ describe('Initialization and usage', function () {
     // validateAsync - should return true for valid
     await expect(validator.validateAsync(1, { type: 'number' })).resolves.toBe(true);
     // validateAsync - should throw for invalid
-    await expect(validator.validateAsync('not-a-number', { type: 'number' })).rejects.toThrow();
+    await expect(validator.validateAsync('not-a-number', { type: 'number' })).rejects.toThrow(ValidateError);
 
     // validateAsyncSafe - should return true for valid
     await expect(validator.validateAsyncSafe(1, { type: 'number' })).resolves.toEqual({ valid: true });
@@ -47,7 +48,7 @@ describe('Initialization and usage', function () {
     // validate - should return true for valid
     await expect(validator.validate(1, { type: 'number' })).resolves.toBe(true);
     // validate - should throw for invalid
-    await expect(validator.validate('not-a-number', { type: 'number' })).rejects.toThrow();
+    await expect(validator.validate('not-a-number', { type: 'number' })).rejects.toThrow(ValidateError);
   });
 
   it('Should create an async-safe validator from factory', async function () {

--- a/test/spec/z-schema-test-suite.spec.ts
+++ b/test/spec/z-schema-test-suite.spec.ts
@@ -143,67 +143,10 @@ describe('ZSchemaTestSuite', function () {
         options.version = version;
       }
 
-      if (!async) {
-        it(
-          testSuite.description + ', ' + test.description,
-          function () {
-            ZSchema.setSchemaReader(undefined);
-
-            const validator = ZSchema.create(options);
-            let caughtErr;
-
-            if (setup) {
-              setup(validator, ZSchema);
-            }
-
-            let valid;
-            try {
-              validator.validateSchema(schema as any);
-              valid = true;
-            } catch (err) {
-              if (!failWithException) {
-                valid = false;
-              }
-              caughtErr = err;
-            }
-
-            if (valid && !validateSchemaOnly) {
-              if (Array.isArray(schema)) {
-                schema = schema[schemaIndex];
-              }
-              try {
-                valid = validator.validate(data, schema as any, validateOptions as any);
-              } catch (err) {
-                valid = false;
-                caughtErr = err;
-              }
-            }
-
-            const err = caughtErr as ValidateError | undefined;
-
-            if (failWithException) {
-              expect(caughtErr).toBeTruthy();
-            } else {
-              expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
-              expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
-            }
-
-            if (test.valid === true) {
-              expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
-            }
-
-            if (after) {
-              after(err?.details ?? err ?? undefined, valid as boolean, data, validator);
-            }
-          },
-          1000
-        );
-      }
-
-      if (async) {
-        it(
-          testSuite.description + ', ' + test.description,
-          async function () {
+      it(
+        testSuite.description + ', ' + test.description,
+        async function () {
+          if (async) {
             const validator = ZSchema.create(options);
             if (setup) {
               setup(validator, ZSchema);
@@ -224,10 +167,60 @@ describe('ZSchemaTestSuite', function () {
             if (after) {
               after(err?.details ?? err ?? undefined, valid, data, validator);
             }
-          },
-          1000
-        );
-      }
+            return;
+          }
+
+          ZSchema.setSchemaReader(undefined);
+
+          const validator = ZSchema.create(options);
+          let caughtErr;
+
+          if (setup) {
+            setup(validator, ZSchema);
+          }
+
+          let valid;
+          try {
+            validator.validateSchema(schema as any);
+            valid = true;
+          } catch (err) {
+            if (!failWithException) {
+              valid = false;
+            }
+            caughtErr = err;
+          }
+
+          if (valid && !validateSchemaOnly) {
+            if (Array.isArray(schema)) {
+              schema = schema[schemaIndex];
+            }
+            try {
+              valid = validator.validate(data, schema as any, validateOptions as any);
+            } catch (err) {
+              valid = false;
+              caughtErr = err;
+            }
+          }
+
+          const err = caughtErr as ValidateError | undefined;
+
+          if (failWithException) {
+            expect(caughtErr).toBeTruthy();
+          } else {
+            expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
+            expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
+          }
+
+          if (test.valid === true) {
+            expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
+          }
+
+          if (after) {
+            after(err?.details ?? err ?? undefined, valid as boolean, data, validator);
+          }
+        },
+        1000
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves the 7 `vitest` lint warnings reported by `npm run check` (oxlint/ultracite). Formatting was already clean; these were lint-only.

### Changes

**`vitest/require-to-throw-message` (5 sites)** — every `toThrow()` / `rejects.toThrow()` now asserts a specific error:
- `new ZSchema()` → `toThrow('do not use new ZSchema()')`
- Sync validation failure → `toThrow('JSON_OBJECT_VALIDATION_FAILED')`
- Async rejections → `toThrow(ValidateError)` (the async path rejects via `getValidateError({ details })` with an **empty** message, so a string matcher can't match — the error *class* is asserted instead).

**`vitest/no-conditional-tests` (2 sites)** — the `if (!async) { it(...) }` / `if (async) { it(...) }` wrappers in the test-suite harness are collapsed into a single inline `it()` that branches *inside* the callback. Keeping the callback inline preserves `valid-title` and `expect-expect` static analysis; the test count and assertions are unchanged (no skipped tests introduced).

### Verification
- `npm run check` → no warnings.
- `npm run build:tests` → type-checks clean.
- The three touched specs: **167/167 pass** (unchanged count).