### PR TITLE
chore: re-enable 10 auto-fixable oxlint rules from the TODO backlog

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -60,14 +60,6 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 95
-    // complexity: trivial
-    // Object literals use longhand `{ foo: foo }` instead of shorthand `{ foo }`; purely mechanical fix.
-    // type: style
-    // Requires ES6 object shorthand notation when the property name matches the variable name.
-    'object-shorthand': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 95
     // complexity: easy
     // Function declarations are used throughout; converting to arrow/expression style is mechanical but touches many files.
     // type: style
@@ -227,14 +219,6 @@ export default defineConfig({
     'no-param-reassign': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 14
-    // complexity: trivial
-    // String escape sequences are not consistently uppercased (e.g., `\xFF` vs `\xff`); purely cosmetic fix.
-    // type: style
-    // Requires escape sequences in strings and regular expressions to use uppercase hex digits.
-    'unicorn/escape-case': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 13
     // complexity: moderate
     // Nullable values are combined with `||` where `??` is semantically more correct; each site needs auditing for falsy vs. nullish intent.
@@ -249,14 +233,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows passing `any`-typed values as arguments to typed function parameters.
     'typescript/no-unsafe-argument': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 13
-    // complexity: trivial
-    // String concatenation with `+` is used where template literals would be clearer; mechanical substitution.
-    // type: style
-    // Requires template literals instead of string concatenation with the `+` operator.
-    'prefer-template': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 13
@@ -363,14 +339,6 @@ export default defineConfig({
     eqeqeq: 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 10
-    // complexity: trivial
-    // Arrow functions have unnecessary block bodies (`=> { return x; }`) where concise bodies (`=> x`) suffice.
-    // type: style
-    // Requires or disallows braces around arrow function bodies when a concise expression body is possible.
-    'arrow-body-style': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 9
     // complexity: moderate
     // Variable names shadow outer-scope variables; renaming requires confirming no semantic collision exists.
@@ -385,22 +353,6 @@ export default defineConfig({
     // type: style
     // Disallows `if` statements as the sole body of an `else` block, requiring `else if` instead.
     'no-lonely-if': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 8
-    // complexity: trivial
-    // `String.prototype.replace()` calls with global regexes can be replaced with `replaceAll()`; mechanical substitution.
-    // type: style
-    // Prefers `String.prototype.replaceAll()` over `.replace()` with a global regular expression flag.
-    'unicorn/prefer-string-replace-all': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 8
-    // complexity: trivial
-    // Hex escape sequences (`\x41`) are used where unicode escapes (`A`) are preferred.
-    // type: style
-    // Disallows hex escape sequences in strings and regular expressions, preferring unicode escapes.
-    'unicorn/no-hex-escape': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 8
@@ -419,28 +371,12 @@ export default defineConfig({
     'promise/avoid-new': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 7
-    // complexity: trivial
-    // Numeric literals lack underscore separators for readability (e.g., `1000000` → `1_000_000`).
-    // type: style
-    // Requires consistent use of numeric separators (`_`) in numeric literals for readability.
-    'unicorn/numeric-separators-style': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 6
     // complexity: trivial
     // Node.js built-in imports use bare specifiers (e.g., `'path'`) instead of the `node:` protocol prefix.
     // type: best-practice
     // Requires the `node:` protocol prefix for Node.js built-in module imports.
     'unicorn/prefer-node-protocol': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 6
-    // complexity: trivial
-    // Array/string indexing uses `arr[arr.length - 1]` instead of `arr.at(-1)`; mechanical substitution.
-    // type: style
-    // Prefers `Array.prototype.at()` and `String.prototype.at()` for negative index access over manual length arithmetic.
-    'unicorn/prefer-at': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 6
@@ -465,14 +401,6 @@ export default defineConfig({
     // type: best-practice
     // Prefers `String.prototype.slice()` over `substring()` and `substr()` for substring extraction.
     'unicorn/prefer-string-slice': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 5
-    // complexity: trivial
-    // `catch (e)` is written where the bound variable `e` is unused; using `catch` (no binding) or `catch (_e)` is preferred.
-    // type: style
-    // Prefers omitting the error binding in `catch` clauses when the caught error is not used.
-    'unicorn/prefer-optional-catch-binding': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 4
@@ -833,14 +761,6 @@ export default defineConfig({
     // type: style
     // Prefers regex literals over `new RegExp()` when the pattern is a static string literal.
     'prefer-regex-literals': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // `Object.prototype.hasOwnProperty.call(obj, key)` is used where `Object.hasOwn(obj, key)` is the modern equivalent.
-    // type: best-practice
-    // Prefers `Object.hasOwn()` over the older `Object.prototype.hasOwnProperty.call()` pattern.
-    'prefer-object-has-own': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1

--- a/scripts/generate-test-coverage-report.mts
+++ b/scripts/generate-test-coverage-report.mts
@@ -64,14 +64,14 @@ function parseCoverageMetrics(metrics: CoverageSummaryFile['total']): CoverageNu
 }
 
 function normalizeCoveragePath(filePath: string, repoRoot: string): string {
-  const normalizedInput = filePath.replace(/\\/g, '/');
-  const relativePath = relative(repoRoot, filePath).replace(/\\/g, '/');
+  const normalizedInput = filePath.replaceAll('\\', '/');
+  const relativePath = relative(repoRoot, filePath).replaceAll('\\', '/');
 
   if (relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath)) {
     return relativePath;
   }
 
-  const normalizedRoot = repoRoot.replace(/\\/g, '/').replace(/\/$/, '');
+  const normalizedRoot = repoRoot.replaceAll('\\', '/').replace(/\/$/, '');
   const prefix = `${normalizedRoot}/`;
 
   if (normalizedInput.startsWith(prefix)) {
@@ -87,12 +87,10 @@ export function parseCoverageSummary(summary: CoverageSummaryFile, repoRoot = pr
 
   const files = Object.entries(summary)
     .filter(([filePath]) => filePath !== 'total')
-    .map(([filePath, metrics]) => {
-      return {
-        ...parseCoverageMetrics(metrics),
-        path: normalizeCoveragePath(filePath, repoRoot),
-      };
-    })
+    .map(([filePath, metrics]) => ({
+      ...parseCoverageMetrics(metrics),
+      path: normalizeCoveragePath(filePath, repoRoot),
+    }))
     .sort((a, b) => a.path.localeCompare(b.path));
 
   return {
@@ -116,9 +114,10 @@ function formatPercent(value: number): string {
 export function renderCoverageReportMarkdown(summary: ParsedCoverageSummary): string {
   const badgeStatus = getCoverageBadgeStatus(summary.totals.linePct);
 
-  const fileRows = summary.files.map((fileCoverage) => {
-    return `| ${fileCoverage.path} | ${formatPercent(fileCoverage.linePct)} | ${formatPercent(fileCoverage.statementPct)} | ${formatPercent(fileCoverage.functionPct)} | ${formatPercent(fileCoverage.branchPct)} |`;
-  });
+  const fileRows = summary.files.map(
+    (fileCoverage) =>
+      `| ${fileCoverage.path} | ${formatPercent(fileCoverage.linePct)} | ${formatPercent(fileCoverage.statementPct)} | ${formatPercent(fileCoverage.functionPct)} | ${formatPercent(fileCoverage.branchPct)} |`
+  );
 
   return [
     '# Test Coverage',

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -121,7 +121,7 @@ const regexValidator: FormatValidatorFn = (input: unknown) => {
   try {
     RegExp(input);
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 };
@@ -132,7 +132,7 @@ const durationValidator: FormatValidatorFn = (input: unknown) => {
   }
 
   // eslint-disable-next-line no-control-regex
-  if (!/^P[\x00-\x7F]*$/.test(input)) {
+  if (!/^P[\u0000-\u007F]*$/.test(input)) {
     return false;
   }
 
@@ -207,7 +207,7 @@ const hasValidPercentEncoding = (str: string): boolean => {
 const uriValidator: FormatValidatorFn = function (uri: unknown) {
   if (typeof uri !== 'string') return true;
   // eslint-disable-next-line no-control-regex
-  if (/[^\x00-\x7F]/.test(uri)) return false;
+  if (/[^\u0000-\u007F]/.test(uri)) return false;
   if (!hasValidPercentEncoding(uri)) return false;
   const match = uri.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/?#]*)/);
   if (match) {
@@ -241,7 +241,7 @@ const uriValidator: FormatValidatorFn = function (uri: unknown) {
 const uriReferenceValidator: FormatValidatorFn = (uri: unknown) => {
   if (typeof uri !== 'string') return true;
   // eslint-disable-next-line no-control-regex
-  if (/[^\x00-\x7F]/.test(uri)) return false;
+  if (/[^\u0000-\u007F]/.test(uri)) return false;
   // URI-reference allows relative URIs
   return /^([a-zA-Z][a-zA-Z0-9+.-]*:)?[^"\\<>^{}^`| ]*$/.test(uri);
 };
@@ -339,7 +339,7 @@ const iriValidator: FormatValidatorFn = (iri: unknown) => {
   try {
     new URL(iri);
     return true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 };

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -740,7 +740,7 @@ export function validate(
   const schemaId = getId(schema);
   const schemaResourceRoot = (schema as JsonSchemaInternal).__$resourceRoot;
   const dynamicScopeEntry = schemaResourceRoot || (isRoot || typeof schemaId === 'string' ? schema : undefined);
-  if (dynamicScopeEntry && dynamicScopeStack[dynamicScopeStack.length - 1] !== dynamicScopeEntry) {
+  if (dynamicScopeEntry && dynamicScopeStack.at(-1) !== dynamicScopeEntry) {
     dynamicScopeStack.push(dynamicScopeEntry);
     pushedDynamicScope = true;
   }

--- a/src/report.ts
+++ b/src/report.ts
@@ -220,20 +220,17 @@ export class Report {
 
     if (returnPathAsString !== true) {
       // Sanitize the path segments (http://tools.ietf.org/html/rfc6901#section-4)
-      return (
-        '#/' +
-        path
-          .map(function (segment) {
-            segment = segment.toString();
+      return `#/${path
+        .map(function (segment) {
+          segment = segment.toString();
 
-            if (isAbsoluteUri(segment)) {
-              return 'uri(' + segment + ')';
-            }
+          if (isAbsoluteUri(segment)) {
+            return `uri(${segment})`;
+          }
 
-            return segment.replace(/~/g, '~0').replace(/\//g, '~1');
-          })
-          .join('/')
-      );
+          return segment.replaceAll('~', '~0').replaceAll('/', '~1');
+        })
+        .join('/')}`;
     }
     return path;
   }
@@ -331,24 +328,24 @@ export class Report {
     }
 
     if (!errorMessage) {
-      throw new Error('No errorMessage known for code ' + errorCode);
+      throw new Error(`No errorMessage known for code ${errorCode}`);
     }
 
     params = params || [];
 
     for (let idx = 0; idx < params.length; idx++) {
       const param = params[idx] === null || isObject(params[idx]) ? JSON.stringify(params[idx]) : params[idx];
-      errorMessage = errorMessage.replace('{' + idx + '}', param.toString());
+      errorMessage = errorMessage.replace(`{${idx}}`, param.toString());
     }
 
     const err: SchemaErrorDetail = {
       code: errorCode,
-      params: params,
+      params,
       message: errorMessage,
       path: this.getPath(this.options.reportPathAsArray),
       schemaPath: this.getSchemaPath(),
       schemaId: this.getSchemaId(),
-      keyword: keyword,
+      keyword,
     };
 
     (err as any)[schemaSymbol] = schema;

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -151,40 +151,40 @@ export const collectReferences = (
   }
 
   if (typeof scopeId === 'string' && (isRootScope || !hasRef || options.useRefObjectScope === true)) {
-    const base = scope.length > 0 ? scope[scope.length - 1] : undefined;
+    const base = scope.length > 0 ? scope.at(-1) : undefined;
     scope.push(resolveSchemaScopeId(base, obj, scopeId));
     addedScope = true;
   }
 
   if (hasRef) {
     results.push({
-      ref: resolveReference(scope[scope.length - 1], obj.$ref!),
+      ref: resolveReference(scope.at(-1), obj.$ref!),
       key: '$ref',
-      obj: obj,
+      obj,
       path: path.slice(0),
     });
   }
   if (typeof obj.$recursiveRef === 'string' && typeof obj.__$recursiveRefResolved === 'undefined') {
     results.push({
-      ref: resolveReference(scope[scope.length - 1], obj.$recursiveRef),
+      ref: resolveReference(scope.at(-1), obj.$recursiveRef),
       key: '$recursiveRef',
-      obj: obj,
+      obj,
       path: path.slice(0),
     });
   }
   if (typeof obj.$dynamicRef === 'string' && typeof obj.__$dynamicRefResolved === 'undefined') {
     results.push({
-      ref: resolveReference(scope[scope.length - 1], obj.$dynamicRef),
+      ref: resolveReference(scope.at(-1), obj.$dynamicRef),
       key: '$dynamicRef',
-      obj: obj,
+      obj,
       path: path.slice(0),
     });
   }
   if (typeof obj.$schema === 'string' && typeof obj.__$schemaResolved === 'undefined') {
     results.push({
-      ref: resolveReference(scope[scope.length - 1], obj.$schema),
+      ref: resolveReference(scope.at(-1), obj.$schema),
       key: '$schema',
-      obj: obj,
+      obj,
       path: path.slice(0),
     });
   }
@@ -264,7 +264,7 @@ const resolveIdScope = (base: string | undefined, id: string) => {
   if (isSimpleIdentifier(id)) {
     const hashIndex = baseStr.indexOf('#');
     const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
-    return baseNoFrag + '#' + id;
+    return `${baseNoFrag}#${id}`;
   }
 
   return resolveReference(base, id);

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -11,20 +11,20 @@ import { compileSchemaRegex } from './utils/schema-regex.js';
 import { isInteger, isObject } from './utils/what-is.js';
 
 const SchemaValidators = {
-  $ref: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  $ref(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
     // http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03
     if (typeof schema.$ref !== 'string') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['$ref', 'string'], undefined, schema, '$ref');
     }
   },
-  $schema: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  $schema(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-core.html#rfc.section.6
     if (typeof schema.$schema !== 'string') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['$schema', 'string'], undefined, schema, '$schema');
     }
   },
-  multipleOf: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  multipleOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.1.1
     if (typeof schema.multipleOf !== 'number') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['multipleOf', 'number'], undefined, schema, 'multipleOf');
@@ -32,13 +32,13 @@ const SchemaValidators = {
       report.addError('KEYWORD_MUST_BE', ['multipleOf', 'strictly greater than 0'], undefined, schema, 'multipleOf');
     }
   },
-  maximum: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  maximum(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.2.1
     if (typeof schema.maximum !== 'number') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['maximum', 'number'], undefined, schema, 'maximum');
     }
   },
-  exclusiveMaximum: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  exclusiveMaximum(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.2.1
     if (report.options.version === 'draft-04') {
       if (typeof schema.exclusiveMaximum !== 'boolean') {
@@ -64,13 +64,13 @@ const SchemaValidators = {
       }
     }
   },
-  minimum: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  minimum(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.3.1
     if (typeof schema.minimum !== 'number') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['minimum', 'number'], undefined, schema, 'minimum');
     }
   },
-  exclusiveMinimum: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  exclusiveMinimum(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version === 'draft-04') {
       // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.3.1
       if (typeof schema.exclusiveMinimum !== 'boolean') {
@@ -96,7 +96,7 @@ const SchemaValidators = {
       }
     }
   },
-  maxLength: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  maxLength(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.1.1
     if (!isInteger(schema.maxLength)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['maxLength', 'integer'], undefined, schema, 'maxLength');
@@ -104,7 +104,7 @@ const SchemaValidators = {
       report.addError('KEYWORD_MUST_BE', ['maxLength', 'greater than, or equal to 0'], undefined, schema, 'maxLength');
     }
   },
-  minLength: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  minLength(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.2.1
     if (!isInteger(schema.minLength)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['minLength', 'integer'], undefined, schema, 'minLength');
@@ -112,7 +112,7 @@ const SchemaValidators = {
       report.addError('KEYWORD_MUST_BE', ['minLength', 'greater than, or equal to 0'], undefined, schema, 'minLength');
     }
   },
-  pattern: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  pattern(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.3.1
     if (typeof schema.pattern !== 'string') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['pattern', 'string'], undefined, schema, 'pattern');
@@ -131,7 +131,7 @@ const SchemaValidators = {
       }
     }
   },
-  additionalItems: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  additionalItems(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.1.1
     if (typeof schema.additionalItems !== 'boolean' && !isObject(schema.additionalItems)) {
       report.addError(
@@ -147,7 +147,7 @@ const SchemaValidators = {
       report.path.pop();
     }
   },
-  items: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  items(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.1.1
     if (Array.isArray(schema.items)) {
       for (let idx = 0; idx < schema.items.length; idx++) {
@@ -180,7 +180,7 @@ const SchemaValidators = {
       schema.additionalItems = false;
     }
   },
-  maxItems: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  maxItems(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.2.1
     if (typeof schema.maxItems !== 'number') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['maxItems', 'integer'], undefined, schema, 'maxItems');
@@ -188,7 +188,7 @@ const SchemaValidators = {
       report.addError('KEYWORD_MUST_BE', ['maxItems', 'greater than, or equal to 0'], undefined, schema, 'maxItems');
     }
   },
-  minItems: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  minItems(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.3.1
     if (!isInteger(schema.minItems)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['minItems', 'integer'], undefined, schema, 'minItems');
@@ -196,13 +196,13 @@ const SchemaValidators = {
       report.addError('KEYWORD_MUST_BE', ['minItems', 'greater than, or equal to 0'], undefined, schema, 'minItems');
     }
   },
-  uniqueItems: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  uniqueItems(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.4.1
     if (typeof schema.uniqueItems !== 'boolean') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['uniqueItems', 'boolean'], undefined, schema, 'uniqueItems');
     }
   },
-  maxProperties: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  maxProperties(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.1.1
     if (!isInteger(schema.maxProperties)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['maxProperties', 'integer'], undefined, schema, 'maxProperties');
@@ -216,7 +216,7 @@ const SchemaValidators = {
       );
     }
   },
-  minProperties: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  minProperties(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.2.1
     if (!isInteger(schema.minProperties)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['minProperties', 'integer'], undefined, schema, 'minProperties');
@@ -230,7 +230,7 @@ const SchemaValidators = {
       );
     }
   },
-  required: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  required(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.3.1
     if (!Array.isArray(schema.required)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['required', 'array'], undefined, schema, 'required');
@@ -253,7 +253,7 @@ const SchemaValidators = {
       }
     }
   },
-  additionalProperties: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  additionalProperties(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.4.1
     if (typeof schema.additionalProperties !== 'boolean' && !isObject(schema.additionalProperties)) {
       report.addError(
@@ -269,7 +269,7 @@ const SchemaValidators = {
       report.path.pop();
     }
   },
-  properties: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  properties(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.4.1
     if (!isObject(schema.properties)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['properties', 'object'], undefined, schema, 'properties');
@@ -299,7 +299,7 @@ const SchemaValidators = {
       report.addError('CUSTOM_MODE_FORCE_PROPERTIES', ['properties'], undefined, schema, 'properties');
     }
   },
-  patternProperties: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  patternProperties(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.4.1
     if (!isObject(schema.patternProperties)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['patternProperties', 'object'], undefined, schema, 'patternProperties');
@@ -332,7 +332,7 @@ const SchemaValidators = {
       report.addError('CUSTOM_MODE_FORCE_PROPERTIES', ['patternProperties'], undefined, schema, 'patternProperties');
     }
   },
-  dependencies: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  dependencies(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.5.1
     if (!isObject(schema.dependencies)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['dependencies', 'object'], undefined, schema, 'dependencies');
@@ -381,7 +381,7 @@ const SchemaValidators = {
       }
     }
   },
-  enum: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  enum(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.1.1
     if (Array.isArray(schema.enum) === false) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['enum', 'array'], undefined, schema, 'enum');
@@ -391,7 +391,7 @@ const SchemaValidators = {
       report.addError('KEYWORD_MUST_BE', ['enum', 'an array with unique elements'], undefined, schema, 'enum');
     }
   },
-  type: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  type(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.2.1
     const primitiveTypes = ['array', 'boolean', 'integer', 'number', 'null', 'object', 'string'];
     const primitiveTypeStr = primitiveTypes.join(',');
@@ -481,7 +481,7 @@ const SchemaValidators = {
       }
     }
   },
-  allOf: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  allOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.3.1
     if (Array.isArray(schema.allOf) === false) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['allOf', 'array'], undefined, schema, 'allOf');
@@ -497,7 +497,7 @@ const SchemaValidators = {
       }
     }
   },
-  anyOf: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  anyOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.4.1
     if (Array.isArray(schema.anyOf) === false) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['anyOf', 'array'], undefined, schema, 'anyOf');
@@ -513,7 +513,7 @@ const SchemaValidators = {
       }
     }
   },
-  oneOf: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  oneOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.5.1
     if (Array.isArray(schema.oneOf) === false) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['oneOf', 'array'], undefined, schema, 'oneOf');
@@ -529,7 +529,7 @@ const SchemaValidators = {
       }
     }
   },
-  not: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  not(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.6.1
     const notSchema = schema.not;
     const isValidNotSchema =
@@ -551,7 +551,7 @@ const SchemaValidators = {
       report.path.pop();
     }
   },
-  if: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  if(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version !== 'draft-07') {
       return;
     }
@@ -567,7 +567,7 @@ const SchemaValidators = {
     this.validateSchema(report, ifSchema as JsonSchemaInternal);
     report.path.pop();
   },
-  then: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  then(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version !== 'draft-07') {
       return;
     }
@@ -583,7 +583,7 @@ const SchemaValidators = {
     this.validateSchema(report, thenSchema as JsonSchemaInternal);
     report.path.pop();
   },
-  else: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  else(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version !== 'draft-07') {
       return;
     }
@@ -599,7 +599,7 @@ const SchemaValidators = {
     this.validateSchema(report, elseSchema as JsonSchemaInternal);
     report.path.pop();
   },
-  definitions: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  definitions(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.7.1
     if (!isObject(schema.definitions)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['definitions', 'object'], undefined, schema, 'definitions');
@@ -615,7 +615,7 @@ const SchemaValidators = {
       }
     }
   },
-  $defs: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  $defs(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version !== 'draft2019-09' && report.options.version !== 'draft2020-12') {
       return;
     }
@@ -635,7 +635,7 @@ const SchemaValidators = {
       report.path.pop();
     }
   },
-  format: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  format(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (this.options.formatAssertions === false) {
       return;
     }
@@ -653,7 +653,7 @@ const SchemaValidators = {
       }
     }
   },
-  contentEncoding: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  contentEncoding(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version !== 'draft-07') {
       return;
     }
@@ -662,7 +662,7 @@ const SchemaValidators = {
       report.addError('KEYWORD_TYPE_EXPECTED', ['contentEncoding', 'string'], undefined, schema, 'contentEncoding');
     }
   },
-  contentMediaType: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  contentMediaType(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     if (report.options.version !== 'draft-07') {
       return;
     }
@@ -671,25 +671,25 @@ const SchemaValidators = {
       report.addError('KEYWORD_TYPE_EXPECTED', ['contentMediaType', 'string'], undefined, schema, 'contentMediaType');
     }
   },
-  id: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  id(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-core.html#rfc.section.7.2
     if (typeof schema.id !== 'string') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['id', 'string'], undefined, schema, 'id');
     }
   },
-  title: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  title(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1
     if (typeof schema.title !== 'string') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['title', 'string'], undefined, schema, 'title');
     }
   },
-  description: function (this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
+  description(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1
     if (typeof schema.description !== 'string') {
       report.addError('KEYWORD_TYPE_EXPECTED', ['description', 'string'], undefined, schema, 'description');
     }
   },
-  default: function (this: SchemaValidator) /* report, schema */ {
+  default(this: SchemaValidator) /* report, schema */ {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2
     // There are no restrictions placed on the value of this keyword.
   },

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -27,7 +27,7 @@ export const isUniqueArray = <T>(arr: T[], indexes?: number[], maxDepth?: number
     const seen = new Set<string>();
     for (let i = 0; i < l; i++) {
       const v = arr[i];
-      const key = typeof v + ':' + String(v);
+      const key = `${typeof v}:${String(v)}`;
       if (seen.has(key)) {
         // Find the first occurrence for the indexes report.
         if (indexes) {

--- a/src/utils/hostname.ts
+++ b/src/utils/hostname.ts
@@ -1,8 +1,8 @@
 import punycode from 'punycode/punycode.js';
 import isIPModule from 'validator/lib/isIP.js';
 
-const IDN_SEPARATOR_REGEX = /[\u3002\uff0e\uff61]/g;
-const IDN_SEPARATOR_TEST_REGEX = /[\u3002\uff0e\uff61]/;
+const IDN_SEPARATOR_REGEX = /[\u3002\uFF0E\uFF61]/g;
+const IDN_SEPARATOR_TEST_REGEX = /[\u3002\uFF0E\uFF61]/;
 
 const splitHostnameLabels = (hostname: string): string[] | null => {
   if (hostname.length === 0 || hostname.length > 255) {
@@ -33,7 +33,7 @@ const toUnicodeLabel = (label: string): string | null => {
   }
   try {
     return punycode.toUnicode(label.toLowerCase());
-  } catch (_e) {
+  } catch {
     return null;
   }
 };
@@ -51,14 +51,14 @@ const isValidIdnUnicodeLabel = (label: string): boolean => {
     return false;
   }
 
-  if (/[\u302e\u302f\u0640\u07fa]/u.test(label)) {
+  if (/[\u302E\u302F\u0640\u07FA]/u.test(label)) {
     return false;
   }
 
   for (let idx = 0; idx < label.length; idx++) {
     const char = label[idx];
 
-    if (char === '\u00b7') {
+    if (char === '\u00B7') {
       if (idx === 0 || idx === label.length - 1 || label[idx - 1] !== 'l' || label[idx + 1] !== 'l') {
         return false;
       }
@@ -70,25 +70,25 @@ const isValidIdnUnicodeLabel = (label: string): boolean => {
       }
     }
 
-    if (char === '\u05f3' || char === '\u05f4') {
+    if (char === '\u05F3' || char === '\u05F4') {
       if (idx === 0 || !isHebrew(label[idx - 1])) {
         return false;
       }
     }
 
-    if (char === '\u200d') {
-      if (idx === 0 || label[idx - 1] !== '\u094d') {
+    if (char === '\u200D') {
+      if (idx === 0 || label[idx - 1] !== '\u094D') {
         return false;
       }
     }
   }
 
-  if (label.includes('\u30fb') && !hasCjkKanaOrHan(label.replace(/\u30fb/g, ''))) {
+  if (label.includes('\u30FB') && !hasCjkKanaOrHan(label.replaceAll('・', ''))) {
     return false;
   }
 
   const hasArabicIndic = /[\u0660-\u0669]/.test(label);
-  const hasExtendedArabicIndic = /[\u06f0-\u06f9]/.test(label);
+  const hasExtendedArabicIndic = /[\u06F0-\u06F9]/.test(label);
   if (hasArabicIndic && hasExtendedArabicIndic) {
     return false;
   }
@@ -129,7 +129,7 @@ const isValidIdnUnicodeLabel = (label: string): boolean => {
 */
 export const isValidHostname = (hostname: string): boolean => {
   // eslint-disable-next-line no-control-regex
-  if (IDN_SEPARATOR_TEST_REGEX.test(hostname) || /[^\x00-\x7F]/.test(hostname)) {
+  if (IDN_SEPARATOR_TEST_REGEX.test(hostname) || /[^\u0000-\u007F]/.test(hostname)) {
     return false;
   }
 

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -75,10 +75,8 @@ export const areEqual = (json1: unknown, json2: unknown, options?: AreEqualOptio
   return false;
 };
 
-export const decodeJSONPointer = (str: string) => {
-  // http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07#section-3
-  return decodeURIComponent(str).replace(/~[0-1]/g, (x) => (x === '~1' ? '/' : '~'));
-};
+export const decodeJSONPointer = (str: string) =>
+  decodeURIComponent(str).replaceAll(/~[0-1]/g, (x) => (x === '~1' ? '/' : '~'));
 
 export const sortedKeys = (obj: Record<string, unknown>): string[] => Object.keys(obj).sort();
 

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -113,7 +113,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
             try {
               const resolved = await promiseResult;
               callback(resolved);
-            } catch (_error) {
+            } catch {
               callback(false);
             }
           },

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -93,7 +93,7 @@ export class ZSchemaBase {
 
     if (typeof schema !== 'string' && typeof schema !== 'boolean' && !isObject(schema)) {
       const e = new Error(
-        'Invalid .validate call - schema must be a string or object but ' + whatIs(schema) + ' was passed!'
+        `Invalid .validate call - schema must be a string or object but ${whatIs(schema)} was passed!`
       );
       if (callback) {
         setTimeout(function () {
@@ -113,7 +113,7 @@ export class ZSchemaBase {
       const schemaName = schema;
       _schema = this.scache.getSchema(report, schemaName)!;
       if (!_schema) {
-        const e = new Error("Schema with id '" + schemaName + "' wasn't found in the validator cache!");
+        const e = new Error(`Schema with id '${schemaName}' wasn't found in the validator cache!`);
         if (callback) {
           setTimeout(function () {
             callback(e, false);
@@ -146,7 +146,7 @@ export class ZSchemaBase {
       report.rootSchema = _schema;
       _schema = get(_schema, options.schemaPath);
       if (!_schema) {
-        const e = new Error("Schema path '" + options.schemaPath + "' wasn't found in the schema!");
+        const e = new Error(`Schema path '${options.schemaPath}' wasn't found in the schema!`);
         if (callback) {
           setTimeout(function () {
             callback(e, false);

--- a/src/z-schema-options.ts
+++ b/src/z-schema-options.ts
@@ -103,7 +103,7 @@ export const normalizeOptions = (options?: ZSchemaOptions) => {
     // check that the options are correctly configured
     for (const key of keys) {
       if (defaultOptions[key] === undefined) {
-        throw new Error('Unexpected option passed to constructor: ' + key);
+        throw new Error(`Unexpected option passed to constructor: ${key}`);
       }
     }
 

--- a/test/ZSchemaTestSuite/AssumeAdditional.ts
+++ b/test/ZSchemaTestSuite/AssumeAdditional.ts
@@ -52,7 +52,7 @@ export default {
       },
       description: 'should fail validation with multiple errors when several other than defined properties are used',
       valid: false,
-      after: function (errs: any) {
+      after(errs: any) {
         expect(errs.length).toBe(2);
         // Error order is not guaranteed — assert presence regardless of position
         const messages = errs.map((e: any) => e.message);

--- a/test/ZSchemaTestSuite/CustomFormats.ts
+++ b/test/ZSchemaTestSuite/CustomFormats.ts
@@ -1,7 +1,7 @@
 export default {
   description: 'registerFormat - Custom formats support',
   version: 'draft-04',
-  setup: function (validator: any, Class: any) {
+  setup(validator: any, Class: any) {
     Class.registerFormat('xstring', function (str: any) {
       return str === 'xxx';
     });
@@ -54,7 +54,7 @@ export default {
         format: 'fillHello',
       },
       valid: true,
-      after: function (err: any, valid: any, obj: any) {
+      after(err: any, valid: any, obj: any) {
         expect(obj.hello).toBe('world');
       },
     },

--- a/test/ZSchemaTestSuite/CustomFormatsAsync.ts
+++ b/test/ZSchemaTestSuite/CustomFormatsAsync.ts
@@ -4,7 +4,7 @@ export default {
   options: {
     asyncTimeout: 500,
   },
-  setup: function (validator: any, Class: any) {
+  setup(validator: any, Class: any) {
     Class.registerFormat('xstring', function (str: any, callback: any) {
       setTimeout(function () {
         callback(str === 'xxx');
@@ -37,7 +37,7 @@ export default {
         format: 'shouldTimeout',
       },
       valid: false,
-      after: function (err: any, valid: any) {
+      after(err: any, valid: any) {
         expect(valid).toBe(false);
         expect(err.length).toBe(1);
         expect(err[0].code).toBe('ASYNC_TIMEOUT');

--- a/test/ZSchemaTestSuite/CustomValidator.ts
+++ b/test/ZSchemaTestSuite/CustomValidator.ts
@@ -40,7 +40,7 @@ export default {
         b: null,
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].code).toBe('INVALID_TYPE');
       },
     },
@@ -50,7 +50,7 @@ export default {
         c: null,
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].code).toBe('SHOULD_FAIL');
         expect(err[0].message).toBe('Forced fail');
       },

--- a/test/ZSchemaTestSuite/ErrorPathAsArray.ts
+++ b/test/ZSchemaTestSuite/ErrorPathAsArray.ts
@@ -17,7 +17,7 @@ export default {
       },
       valid: false,
       validateSchemaOnly: true,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].path).toEqual(['properties', 'name']);
       },
     },

--- a/test/ZSchemaTestSuite/ErrorPathAsJSONPointer.ts
+++ b/test/ZSchemaTestSuite/ErrorPathAsJSONPointer.ts
@@ -14,7 +14,7 @@ export default {
       },
       valid: false,
       validateSchemaOnly: true,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].path).toEqual('#/properties/~0name~1age');
       },
     },

--- a/test/ZSchemaTestSuite/ErrorPathContainsIntegerIndex.ts
+++ b/test/ZSchemaTestSuite/ErrorPathContainsIntegerIndex.ts
@@ -22,7 +22,7 @@ export default {
       },
       valid: false,
       validateSchemaOnly: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].path).toEqual(['list', 0]);
       },
     },

--- a/test/ZSchemaTestSuite/IncludeErrors.ts
+++ b/test/ZSchemaTestSuite/IncludeErrors.ts
@@ -59,7 +59,7 @@ export default {
       },
       description: 'should fail validation when the specified error is present only for that error',
       valid: false,
-      after: function (errs: any) {
+      after(errs: any) {
         expect(errs.length).toBe(1);
         expect(errs[0].code).toBe('INVALID_TYPE');
       },
@@ -79,7 +79,7 @@ export default {
       },
       description: 'should fail validation for all errors when no `includeErrors` array is provided.',
       valid: false,
-      after: function (errs: any) {
+      after(errs: any) {
         expect(errs.length).toBe(2);
       },
     },
@@ -101,7 +101,7 @@ export default {
       },
       description: 'should fail validation for all errors when empty array is provided.',
       valid: false,
-      after: function (errs: any) {
+      after(errs: any) {
         expect(errs.length).toBe(2);
       },
     },

--- a/test/ZSchemaTestSuite/Issue101.ts
+++ b/test/ZSchemaTestSuite/Issue101.ts
@@ -10,7 +10,7 @@ export default {
       description: 'should fail with correct error',
       data: null,
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err.message).toBe('Invalid .validate call - schema must be a string or object but null was passed!');
       },
     },

--- a/test/ZSchemaTestSuite/Issue102.ts
+++ b/test/ZSchemaTestSuite/Issue102.ts
@@ -6,7 +6,7 @@ export default {
       schema: {},
       data: {},
       valid: true,
-      after: function (err: any, valid: any, data: any, validator: any) {
+      after(err: any, valid: any, data: any, validator: any) {
         validator.getResolvedSchema('http://json-schema.org/draft-04/schema#');
       },
     },

--- a/test/ZSchemaTestSuite/Issue103.ts
+++ b/test/ZSchemaTestSuite/Issue103.ts
@@ -48,7 +48,7 @@ export default {
       description: 'should fail with correct error - sync',
       validateSchemaOnly: true,
       valid: false,
-      after: function (errs: any) {
+      after(errs: any) {
         expect(errs.length).toBe(1);
       },
     },
@@ -57,7 +57,7 @@ export default {
       description: 'should fail with correct error - async',
       validateSchemaOnly: true,
       valid: false,
-      after: function (errs: any) {
+      after(errs: any) {
         expect(errs.length).toBe(1);
       },
     },

--- a/test/ZSchemaTestSuite/Issue107.ts
+++ b/test/ZSchemaTestSuite/Issue107.ts
@@ -1,6 +1,6 @@
 export default {
   description: 'Issue #107 - add Support for Controlling Remote Schema Reading',
-  setup: function (validator: any, ZSchema: any) {
+  setup(validator: any, ZSchema: any) {
     ZSchema.setSchemaReader(function (_uri: any) {
       return {
         type: 'string',

--- a/test/ZSchemaTestSuite/Issue12.ts
+++ b/test/ZSchemaTestSuite/Issue12.ts
@@ -63,7 +63,7 @@ export default {
       },
       validateSchemaOnly: true,
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].code).toBe('UNRESOLVABLE_REFERENCE');
       },
     },

--- a/test/ZSchemaTestSuite/Issue125.ts
+++ b/test/ZSchemaTestSuite/Issue125.ts
@@ -2,7 +2,7 @@
 
 export default {
   description: 'Issue #125 - Why process format if type validation fails',
-  setup: function (validator: any, Class: any) {
+  setup(validator: any, Class: any) {
     Class.registerFormat('test', function (item: any) {
       return typeof item === 'string';
     });
@@ -26,7 +26,7 @@ export default {
         callbacks: [true],
       },
       valid: false,
-      after: function (err: any, _valid: any, _data: any, _validator: any) {
+      after(err: any, _valid: any, _data: any, _validator: any) {
         expect(err.length).toBe(1);
         expect(err[0].code).toBe('INVALID_TYPE');
       },

--- a/test/ZSchemaTestSuite/Issue126.ts
+++ b/test/ZSchemaTestSuite/Issue126.ts
@@ -7,7 +7,7 @@ export default {
   tests: [
     {
       description: 'should fail compilation with unresolvable reference',
-      setup: function (validator: any) {
+      setup(validator: any) {
         validator.setRemoteReference(REF_NAME, {
           $schema: 'http://json-schema.org/draft-04/schema#',
           id: REF_NAME,
@@ -30,7 +30,7 @@ export default {
       },
       validateSchemaOnly: true,
       valid: false,
-      after: function (err: any, valid: any, data: any, validator: any) {
+      after(err: any, valid: any, data: any, validator: any) {
         err.forEach(function (e: any) {
           if (e.params.indexOf(REF_NAME) !== -1) {
             expect(e.code).not.toBe('UNRESOLVABLE_REFERENCE');

--- a/test/ZSchemaTestSuite/Issue13.ts
+++ b/test/ZSchemaTestSuite/Issue13.ts
@@ -160,7 +160,7 @@ export default {
         c: 'C',
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].code).toBe('INVALID_TYPE');
         expect(err[1].code).toBe('INVALID_TYPE');
       },

--- a/test/ZSchemaTestSuite/Issue130.ts
+++ b/test/ZSchemaTestSuite/Issue130.ts
@@ -31,7 +31,7 @@ export default {
         },
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         err.forEach(function (e: any) {
           expect(e.path).toBe('#/this~1that/t~1h~1e~1 ~1o~1t~1h~1e~1r');
         });

--- a/test/ZSchemaTestSuite/Issue131.ts
+++ b/test/ZSchemaTestSuite/Issue131.ts
@@ -27,7 +27,7 @@ export default {
       },
       data: { nested: {} },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err.length).toBe(2);
         if (err.length === 2) {
           expect(err[0].code).toBe('OBJECT_MISSING_REQUIRED_PROPERTY');

--- a/test/ZSchemaTestSuite/Issue139.ts
+++ b/test/ZSchemaTestSuite/Issue139.ts
@@ -45,7 +45,7 @@ export default {
         required: ['recType', 'roleA', 'roleB'],
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err.length).toBe(3);
         err.forEach(function (e: any) {
           expect(e.code).toBe('UNRESOLVABLE_REFERENCE');

--- a/test/ZSchemaTestSuite/Issue146.ts
+++ b/test/ZSchemaTestSuite/Issue146.ts
@@ -18,7 +18,7 @@ export default {
       },
       data: { password: 'short' },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err.length).toBe(2);
       },
     },

--- a/test/ZSchemaTestSuite/Issue151.ts
+++ b/test/ZSchemaTestSuite/Issue151.ts
@@ -16,7 +16,7 @@ export default {
         props: {},
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].code).toBe('OBJECT_PROPERTIES_MINIMUM');
       },
     },

--- a/test/ZSchemaTestSuite/Issue199.ts
+++ b/test/ZSchemaTestSuite/Issue199.ts
@@ -23,7 +23,7 @@ const schema2 = {
 
 export default {
   description: 'Issue #47 - references to draft4 subschema are not working',
-  setup: function (validator: any) {
+  setup(validator: any) {
     validator.setRemoteReference(ref1, schema1);
     validator.setRemoteReference(ref2, schema2);
   },

--- a/test/ZSchemaTestSuite/Issue209.ts
+++ b/test/ZSchemaTestSuite/Issue209.ts
@@ -6,7 +6,7 @@ export default {
   options: {
     asyncTimeout: 2000,
   },
-  setup: function (validator: any, Class: any) {
+  setup(validator: any, Class: any) {
     if (testAsync) {
       // asynchronous validator
       Class.registerFormat('string-length', function (str: any, callback: any) {
@@ -37,7 +37,7 @@ export default {
       description: 'Wrong path in custom format async validator',
       data: { userId: '1' },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].path).toEqual('#/userId');
       },
     },

--- a/test/ZSchemaTestSuite/Issue229.ts
+++ b/test/ZSchemaTestSuite/Issue229.ts
@@ -15,13 +15,13 @@ export default {
                       negativeBatch: {
                         type: 'number',
                         minimum: 0,
-                        maximum: 999999999.99,
+                        maximum: 999_999_999.99,
                         title: 'Negative Batch $',
                       },
                       amountOfCreditsInBatch: {
                         type: 'number',
                         minimum: 0,
-                        maximum: 999999999.99,
+                        maximum: 999_999_999.99,
                         title: 'Amount of Credits in a Batch $',
                       },
                       numberOfCreditsInBatch: {
@@ -41,14 +41,14 @@ export default {
       data: {
         setup: {
           excessiveCredit: {
-            amountOfCreditsInBatch: -15000.21,
-            negativeBatch: 25001,
+            amountOfCreditsInBatch: -15_000.21,
+            negativeBatch: 25_001,
             numberOfCreditsInBatch: 155,
           },
         },
       },
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err.length).toBe(1);
         expect(err[0].code).toBe('MINIMUM');
         expect(err[0].path).toBe('#/setup/excessiveCredit/amountOfCreditsInBatch');

--- a/test/ZSchemaTestSuite/Issue26.ts
+++ b/test/ZSchemaTestSuite/Issue26.ts
@@ -49,7 +49,7 @@ export default {
       },
       data: 'string',
       valid: false,
-      after: function (errors: any) {
+      after(errors: any) {
         expect(errors[0].code).toBe('KEYWORD_UNDEFINED_STRICT');
       },
     },

--- a/test/ZSchemaTestSuite/Issue47.ts
+++ b/test/ZSchemaTestSuite/Issue47.ts
@@ -5,7 +5,7 @@ const json = import('./files/Issue47/sample.json');
 
 export default {
   description: 'Issue #47 - references to draft4 subschema are not working',
-  setup: function (validator: any) {
+  setup(validator: any) {
     validator.setRemoteReference('http://json-schema.orgx/draft-04/schema', draft4);
   },
   tests: [

--- a/test/ZSchemaTestSuite/Issue53.ts
+++ b/test/ZSchemaTestSuite/Issue53.ts
@@ -10,7 +10,7 @@ export default {
       },
       data: '000 a',
       valid: false,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].description).toBe('Four numbers followed by an optional space and then two letters.');
       },
     },

--- a/test/ZSchemaTestSuite/Issue57.ts
+++ b/test/ZSchemaTestSuite/Issue57.ts
@@ -547,7 +547,7 @@ const apiDeclarationJson = {
 
 export default {
   description: 'Issue #57 - maximum call stack exceeded error',
-  setup: function (validator: any, Class: any) {
+  setup(validator: any, Class: any) {
     Class.registerFormat('mime-type', function () {
       return true;
     });

--- a/test/ZSchemaTestSuite/Issue58.ts
+++ b/test/ZSchemaTestSuite/Issue58.ts
@@ -56,7 +56,7 @@ export default {
       },
       validateSchemaOnly: true,
       valid: false,
-      after: function (err: Error, valid: boolean, data: unknown, validator: ZSchema) {
+      after(err: Error, valid: boolean, data: unknown, validator: ZSchema) {
         const missingReferences = validator.getMissingReferences(
           new ValidateError('', err as unknown as SchemaErrorDetail[])
         );

--- a/test/ZSchemaTestSuite/Issue64.ts
+++ b/test/ZSchemaTestSuite/Issue64.ts
@@ -19,7 +19,7 @@ export default {
       },
       valid: false,
       validateSchemaOnly: true,
-      after: function (err: any) {
+      after(err: any) {
         expect(err[0].path).toEqual('#/properties/friends/items');
       },
     },

--- a/test/ZSchemaTestSuite/Issue67.ts
+++ b/test/ZSchemaTestSuite/Issue67.ts
@@ -3,7 +3,7 @@ export default {
   tests: [
     {
       description: 'should pass validation #1',
-      setup: function (validator: any, Class: any) {
+      setup(validator: any, Class: any) {
         Class.registerFormat('not-blank', function () {
           return true;
         });

--- a/test/ZSchemaTestSuite/Issue71.ts
+++ b/test/ZSchemaTestSuite/Issue71.ts
@@ -20,7 +20,7 @@ export default {
 
       valid: false,
 
-      after: function (errors: any) {
+      after(errors: any) {
         expect(errors.length).toBe(2);
       },
     },
@@ -48,7 +48,7 @@ export default {
 
       valid: false,
 
-      after: function (errors: any) {
+      after(errors: any) {
         expect(errors.length).toBe(2);
       },
     },
@@ -76,7 +76,7 @@ export default {
 
       valid: false,
 
-      after: function (errors: any) {
+      after(errors: any) {
         expect(errors.length).toBeGreaterThan(1);
       },
     },
@@ -108,7 +108,7 @@ export default {
 
       valid: false,
 
-      after: function (errors: any) {
+      after(errors: any) {
         expect(errors.length).toBeGreaterThan(1);
       },
     },

--- a/test/ZSchemaTestSuite/Issue85.ts
+++ b/test/ZSchemaTestSuite/Issue85.ts
@@ -12,7 +12,7 @@ const originalSchema = {
 const getKeys = function (obj: any) {
   const arr: string[] = [];
   for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       arr.push(key);
     }
   }
@@ -32,7 +32,7 @@ export default {
         inner: 5,
       },
       valid: true,
-      after: function () {
+      after() {
         expect(getKeys(originalSchema).length).toBe(originalSchemaKeys.length);
         expect(getKeys(innerSchemaKeys).length).toBe(innerSchemaKeys.length);
       },

--- a/test/ZSchemaTestSuite/Issue94.ts
+++ b/test/ZSchemaTestSuite/Issue94.ts
@@ -34,7 +34,7 @@ export default {
       schema: [schema1, schema2],
       validateSchemaOnly: true,
       valid: true,
-      after: function (err: any, valid: any, data: any, validator: any) {
+      after(err: any, valid: any, data: any, validator: any) {
         const newSch = validator.getResolvedSchema('person-object');
         expect(isequal(newSch, expectedResult)).toBe(true);
       },

--- a/test/ZSchemaTestSuite/Issue98.ts
+++ b/test/ZSchemaTestSuite/Issue98.ts
@@ -18,7 +18,7 @@ export default {
       },
       data: {},
       valid: false,
-      after: function (err: any, _valid: any, _data: any, _validator: any) {
+      after(err: any, _valid: any, _data: any, _validator: any) {
         expect(err.length).toBe(1);
         expect(err[0].code).toBe('ONE_OF_MISSING');
         expect(err[0].inner.length).toBe(4);

--- a/test/ZSchemaTestSuite/NoExtraKeywords.ts
+++ b/test/ZSchemaTestSuite/NoExtraKeywords.ts
@@ -35,7 +35,7 @@ export default {
       description:
         'should fail schema validation, because schema is validated by $schema and number is not valid for title',
       valid: false,
-      after: function (err: any, valid: any) {
+      after(err: any, valid: any) {
         expect(valid).toBe(false);
         expect(err[0].code).toBe('PARENT_SCHEMA_VALIDATION_FAILED');
       },

--- a/test/ZSchemaTestSuite/getRegisteredFormats.ts
+++ b/test/ZSchemaTestSuite/getRegisteredFormats.ts
@@ -2,7 +2,7 @@
 
 export default {
   description: 'getRegisteredFormats - return an array of format names',
-  setup: function (validator: any, Class: any) {
+  setup(validator: any, Class: any) {
     Class.registerFormat('phone', function (_str: any) {
       return true;
     });

--- a/test/lib/create-manifest.ts
+++ b/test/lib/create-manifest.ts
@@ -13,7 +13,7 @@ const getJsonFiles = async (directory: string, base: string): Promise<string[]> 
         return getJsonFiles(fullPath, base);
       }
       if (entry.isFile() && entry.name.endsWith('.json')) {
-        return '/' + [relative(base, fullPath).replace(/\\/g, '/')];
+        return `/${relative(base, fullPath).replaceAll('\\', '/')}`;
       }
       return [];
     })

--- a/test/spec/async-validation.node-spec.ts
+++ b/test/spec/async-validation.node-spec.ts
@@ -6,10 +6,7 @@ describe('Async Format Validation Integration', () => {
   it('should validate successfully with async format validator', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => {
-      // Simulate async check
-      return typeof input === 'string' && input === 'valid';
-    };
+    const asyncValidator = async (input: unknown): Promise<boolean> => typeof input === 'string' && input === 'valid';
 
     validator.registerFormat('async-check', asyncValidator);
 
@@ -26,9 +23,7 @@ describe('Async Format Validation Integration', () => {
   it('should fail validation with async format validator', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => {
-      return typeof input === 'string' && input === 'valid';
-    };
+    const asyncValidator = async (input: unknown): Promise<boolean> => typeof input === 'string' && input === 'valid';
 
     validator.registerFormat('async-check', asyncValidator);
 
@@ -45,13 +40,10 @@ describe('Async Format Validation Integration', () => {
   it('should work with async format validators in oneOf', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const syncValidator = (input: unknown): boolean => {
-      return typeof input === 'string' && input === 'sync-valid';
-    };
+    const syncValidator = (input: unknown): boolean => typeof input === 'string' && input === 'sync-valid';
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => {
-      return typeof input === 'string' && input === 'async-valid';
-    };
+    const asyncValidator = async (input: unknown): Promise<boolean> =>
+      typeof input === 'string' && input === 'async-valid';
 
     validator.registerFormat('sync-check', syncValidator);
     validator.registerFormat('async-check', asyncValidator);
@@ -72,9 +64,8 @@ describe('Async Format Validation Integration', () => {
   it('should work with async format validators in anyOf', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => {
-      return typeof input === 'string' && input === 'async-valid';
-    };
+    const asyncValidator = async (input: unknown): Promise<boolean> =>
+      typeof input === 'string' && input === 'async-valid';
 
     validator.registerFormat('async-check', asyncValidator);
 
@@ -91,9 +82,8 @@ describe('Async Format Validation Integration', () => {
   it('should fail validation when async format validator in oneOf fails', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => {
-      return typeof input === 'string' && input === 'async-valid';
-    };
+    const asyncValidator = async (input: unknown): Promise<boolean> =>
+      typeof input === 'string' && input === 'async-valid';
 
     validator.registerFormat('async-check', asyncValidator);
 

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -7,9 +7,7 @@ describe('Format Validators', () => {
     it('should register an async format validator', () => {
       const validator = ZSchema.create();
 
-      const asyncValidator = async (input: unknown): Promise<boolean> => {
-        return typeof input === 'string' && input.length > 3;
-      };
+      const asyncValidator = async (input: unknown): Promise<boolean> => typeof input === 'string' && input.length > 3;
 
       validator.registerFormat('async-test', asyncValidator);
 

--- a/test/spec/issue-224.spec.ts
+++ b/test/spec/issue-224.spec.ts
@@ -51,7 +51,7 @@ describe('Issue #224: Not getting all schema errors from optional parent object'
             },
             birthUnixTime: {
               description: '',
-              default: 1415273168,
+              default: 1_415_273_168,
               type: 'number',
             },
           },
@@ -122,7 +122,7 @@ describe('Issue #224: Not getting all schema errors from optional parent object'
             },
             birthUnixTime: {
               description: '',
-              default: 1415273168,
+              default: 1_415_273_168,
               type: 'number',
             },
           },

--- a/test/spec/issue-69.spec.ts
+++ b/test/spec/issue-69.spec.ts
@@ -44,7 +44,7 @@ describe('Issue #69: Floating point precision in multipleOf validation', () => {
 
     const schema: JsonSchema = {
       type: 'integer',
-      multipleOf: 0.123456789,
+      multipleOf: 0.123_456_789,
     };
 
     const data = 1e308;

--- a/test/spec/json-schema-test-suite.common.ts
+++ b/test/spec/json-schema-test-suite.common.ts
@@ -52,7 +52,7 @@ export async function runTests({ reader }: { reader: <T>(testFilePath: string) =
   await Promise.all(
     remoteFiles.map(async (file) => {
       // desired serverPath example: http://localhost:1234/draft4/locationIndependentIdentifier.json
-      const serverPath = 'http://localhost:1234/' + file.slice('/json-schema-test-suite/remotes/'.length);
+      const serverPath = `http://localhost:1234/${file.slice('/json-schema-test-suite/remotes/'.length)}`;
       const schema = await reader<JsonSchema>(file);
       ZSchema.setRemoteReference(serverPath, schema);
     })

--- a/test/spec/unicode-pattern.spec.ts
+++ b/test/spec/unicode-pattern.spec.ts
@@ -6,7 +6,7 @@ function supportsUnicodePropertyEscapes() {
   try {
     const re = new RegExp('^\\p{L}+$', 'u');
     return re.test('abc') === true;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }
@@ -46,15 +46,15 @@ describe('Unicode property escapes in pattern keyword', () => {
 
 describe('unicodeLength', () => {
   it('should count lone low surrogate as one character', () => {
-    expect(unicodeLength('\udc00')).toBe(1);
+    expect(unicodeLength('\uDC00')).toBe(1);
   });
 
   it('should count lone high surrogate at end of string as one character', () => {
-    expect(unicodeLength('\ud800')).toBe(1);
+    expect(unicodeLength('\uD800')).toBe(1);
   });
 
   it('should count unmatched high surrogate followed by ASCII as two characters', () => {
-    expect(unicodeLength('\ud800a')).toBe(2);
+    expect(unicodeLength('\uD800a')).toBe(2);
   });
 
   it('should count surrogate pair as one character', () => {

--- a/test/spec/z-schema-test-suite.spec.ts
+++ b/test/spec/z-schema-test-suite.spec.ts
@@ -143,84 +143,80 @@ describe('ZSchemaTestSuite', function () {
         options.version = version;
       }
 
-      it(
-        testSuite.description + ', ' + test.description,
-        async function () {
-          if (async) {
-            const validator = ZSchema.create(options);
-            if (setup) {
-              setup(validator, ZSchema);
-            }
-
-            if (Array.isArray(schema)) {
-              schema = schema[schemaIndex];
-            }
-
-            const response = await validator.validateAsyncSafe(data, schema as any, validateOptions as any);
-            const { valid, err } = response;
-
-            expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
-            expect(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
-            if (test.valid === true) {
-              expect(err).toBe(undefined /*, 'errors are not undefined when test is valid'*/);
-            }
-            if (after) {
-              after(err?.details ?? err ?? undefined, valid, data, validator);
-            }
-            return;
-          }
-
-          ZSchema.setSchemaReader(undefined);
-
+      it(`${testSuite.description}, ${test.description}`, async function () {
+        if (async) {
           const validator = ZSchema.create(options);
-          let caughtErr;
-
           if (setup) {
             setup(validator, ZSchema);
           }
 
-          let valid;
+          if (Array.isArray(schema)) {
+            schema = schema[schemaIndex];
+          }
+
+          const response = await validator.validateAsyncSafe(data, schema as any, validateOptions as any);
+          const { valid, err } = response;
+
+          expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
+          expect(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
+          if (test.valid === true) {
+            expect(err).toBe(undefined /*, 'errors are not undefined when test is valid'*/);
+          }
+          if (after) {
+            after(err?.details ?? err ?? undefined, valid, data, validator);
+          }
+          return;
+        }
+
+        ZSchema.setSchemaReader(undefined);
+
+        const validator = ZSchema.create(options);
+        let caughtErr;
+
+        if (setup) {
+          setup(validator, ZSchema);
+        }
+
+        let valid;
+        try {
+          validator.validateSchema(schema as any);
+          valid = true;
+        } catch (err) {
+          if (!failWithException) {
+            valid = false;
+          }
+          caughtErr = err;
+        }
+
+        if (valid && !validateSchemaOnly) {
+          if (Array.isArray(schema)) {
+            schema = schema[schemaIndex];
+          }
           try {
-            validator.validateSchema(schema as any);
-            valid = true;
+            valid = validator.validate(data, schema as any, validateOptions as any);
           } catch (err) {
-            if (!failWithException) {
-              valid = false;
-            }
+            valid = false;
             caughtErr = err;
           }
+        }
 
-          if (valid && !validateSchemaOnly) {
-            if (Array.isArray(schema)) {
-              schema = schema[schemaIndex];
-            }
-            try {
-              valid = validator.validate(data, schema as any, validateOptions as any);
-            } catch (err) {
-              valid = false;
-              caughtErr = err;
-            }
-          }
+        const err = caughtErr as ValidateError | undefined;
 
-          const err = caughtErr as ValidateError | undefined;
+        if (failWithException) {
+          expect(caughtErr).toBeTruthy();
+        } else {
+          expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
+          expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
+        }
 
-          if (failWithException) {
-            expect(caughtErr).toBeTruthy();
-          } else {
-            expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
-            expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
-          }
+        if (test.valid === true) {
+          expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
+        }
 
-          if (test.valid === true) {
-            expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
-          }
-
-          if (after) {
-            after(err?.details ?? err ?? undefined, valid as boolean, data, validator);
-          }
-        },
-        1000
-      );
+        if (after) {
+          after(err?.details ?? err ?? undefined, valid as boolean, data, validator);
+        }
+      }, 1000);
     });
   });
 });


### PR DESCRIPTION
## What

Re-enables 10 of the easiest rules from the documented `oxlint.config.ts` TODO backlog — rules whose violations oxlint can auto-fix deterministically with **no behavioral change** — and applies the fixes across `src/` and `test/`.

Each rule was removed from the `rules` block (reverting it to the ultracite preset's `error`), then `npm run fix` rewrote the code.

| Rule | Kind |
|------|------|
| `object-shorthand` (95) | longhand `{foo: foo}`/`m: function(){}` → shorthand |
| `prefer-template` (12) | `'a' + b` → template literal |
| `unicorn/escape-case` (14) | lowercase → uppercase hex escapes (identical value) |
| `unicorn/no-hex-escape` (8) | `\xNN` → `\u00NN` (identical code points) |
| `unicorn/prefer-string-replace-all` (8) | `.replace(/…/g)` → `.replaceAll(…)` |
| `unicorn/prefer-optional-catch-binding` (5) | drop unused `catch` binding |
| `unicorn/prefer-at` (6) | `arr[arr.length-1]` → `arr.at(-1)` |
| `unicorn/numeric-separators-style` (7) | group long numerics with `_` |
| `prefer-object-has-own` (1) | `hasOwnProperty.call` → `Object.hasOwn` |
| `arrow-body-style` (10) | `=> { return x }` → `=> x` |

## Notes

- **`prefer-node-protocol` deliberately left disabled** — it would rewrite `src/utils/hostname.ts`'s `import … from 'punycode/punycode.js'` to `node:punycode/punycode.js`, breaking resolution to the userland `punycode` dependency.
- `object-shorthand` converts the `this`-using keyword validators in `schema-validator.ts` to method shorthand; invocation is via `.call(this, …)`, which preserves the dynamic `this` binding.
- Two manual touch-ups were needed where an autofix cascaded: `prefer-string-replace-all` is suggestion-only in oxlint (applied by hand), and a pre-existing `'/' + [array]` construct in `test/lib/create-manifest.ts` was simplified after `prefer-template` surfaced a `restrict-template-expressions` error.

## Verification

- `npm run check` — clean (lint + format)
- `npm run build:tests` — clean (type-check)
- `npm test` — 32,389 tests pass (node + browser), 0 failures