### PR TITLE
chore: promote intentional oxlint overrides out of the TODO backlog

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -13,26 +13,24 @@ export default defineConfig({
     node: true,
   },
   rules: {
-    // ── Intentional project rules (KEEP ENABLED) ──────────────────────
-    'typescript/consistent-type-imports': 'error',
-    'typescript/no-explicit-any': 'off',
+    // ── Intentional project rules on top of ultracite defaults
+    'func-style': ['error', 'declaration', { allowArrowFunctions: true }],
+    'no-inline-comments': 'off',
+    'no-plusplus': 'off',
     'no-unused-vars': [
       'error',
       { args: 'after-used', argsIgnorePattern: '^_', caughtErrors: 'all', caughtErrorsIgnorePattern: '^_' },
     ],
-    // Disabled intentionally: the TODO blocks below are our documented rule backlog.
     'no-warning-comments': 'off',
+    'require-unicode-regexp': 'off',
+    'sort-keys': 'off',
+    'typescript/consistent-type-imports': 'error',
+    'typescript/no-explicit-any': 'off',
+    'typescript/no-non-null-assertion': 'off',
+    'unicorn/prefer-node-protocol': 'off',
 
     // ── TODO: rules from the ultracite preset currently reporting errors ──
     // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 736
-    // complexity: moderate
-    // Object keys throughout the codebase are not sorted alphabetically; enforcing would require a large mechanical rewrite.
-    // type: style
-    // Requires all keys in object literals to be sorted in alphabetical order.
-    'sort-keys': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 171
@@ -43,28 +41,12 @@ export default defineConfig({
     'func-names': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 113
-    // complexity: moderate
-    // Non-null assertions (`!`) are used pervasively where callers have guaranteed non-null values; removing them requires local refactors or explicit guards.
-    // type: type-safety
-    // Disallows the non-null assertion operator (`!`) which suppresses TypeScript's null-safety checks.
-    'typescript/no-non-null-assertion': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 105
     // complexity: dangerous
     // Member access on `any`-typed values is common in schema traversal code; fixing requires narrowing types or adding casts throughout.
     // type: type-safety
     // Disallows accessing properties on values typed as `any`, which bypasses TypeScript's type checking.
     'typescript/no-unsafe-member-access': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 95
-    // complexity: easy
-    // Function declarations are used throughout; converting to arrow/expression style is mechanical but touches many files.
-    // type: style
-    // Enforces a consistent style for function definitions (declaration vs. expression vs. arrow).
-    'func-style': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 81
@@ -89,30 +71,6 @@ export default defineConfig({
     // type: style
     // Requires filenames to follow a specified case convention (e.g., kebab-case).
     'unicorn/filename-case': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 64
-    // complexity: moderate
-    // Regex literals lack the `u` or `v` flag; adding the flag may change surrogate-pair handling and requires auditing each pattern.
-    // type: bug-prevention
-    // Requires the `u` (or `v`) flag on regular expression literals to enable full Unicode mode and stricter parsing.
-    'require-unicode-regexp': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 54
-    // complexity: trivial
-    // `++`/`--` operators are used in loops and numeric logic; replacing with `+= 1` is mechanical.
-    // type: style
-    // Disallows the unary `++` and `--` operators in favour of explicit `+= 1` / `-= 1`.
-    'no-plusplus': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 52
-    // complexity: easy
-    // Inline `// eslint-disable` and other inline directive comments are present; moving to block-level disables or fixing the underlying issues is required.
-    // type: style
-    // Disallows inline comments (comments on the same line as code).
-    'no-inline-comments': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 37
@@ -369,14 +327,6 @@ export default defineConfig({
     // type: best-practice
     // Disallows explicit `new Promise()` construction when a simpler promise-returning API is available.
     'promise/avoid-new': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 6
-    // complexity: trivial
-    // Node.js built-in imports use bare specifiers (e.g., `'path'`) instead of the `node:` protocol prefix.
-    // type: best-practice
-    // Requires the `node:` protocol prefix for Node.js built-in module imports.
-    'unicorn/prefer-node-protocol': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 6

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -204,7 +204,7 @@ const hasValidPercentEncoding = (str: string): boolean => {
   return true;
 };
 
-const uriValidator: FormatValidatorFn = function (uri: unknown) {
+const uriValidator: FormatValidatorFn = (uri: unknown) => {
   if (typeof uri !== 'string') return true;
   // eslint-disable-next-line no-control-regex
   if (/[^\u0000-\u007F]/.test(uri)) return false;

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -560,7 +560,7 @@ export const JsonValidators: Record<keyof JsonSchemaAll, JsonValidatorFn> = {
 // recurseArray
 // ---------------------------------------------------------------------------
 
-const recurseArray = function (this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Array<unknown>) {
+function recurseArray(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Array<unknown>) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.2
 
   const schemaUri = typeof schema.$schema === 'string' ? schema.$schema : undefined;
@@ -618,13 +618,13 @@ const recurseArray = function (this: ZSchemaBase, report: Report, schema: JsonSc
       report.path.pop();
     }
   }
-};
+}
 
 // ---------------------------------------------------------------------------
 // recurseObject
 // ---------------------------------------------------------------------------
 
-const recurseObject = function (this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Record<any, any>) {
+function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Record<any, any>) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3
 
   // If "additionalProperties" is absent, it is considered present with an empty schema as a value.
@@ -691,7 +691,7 @@ const recurseObject = function (this: ZSchemaBase, report: Report, schema: JsonS
       }
     }
   }
-};
+}
 
 // ---------------------------------------------------------------------------
 // validate — main entry point

--- a/src/validation/shared.ts
+++ b/src/validation/shared.ts
@@ -15,16 +15,11 @@ export type JsonValidatorFn = (this: ZSchemaBase, report: Report, schema: JsonSc
 // Draft / vocabulary helpers
 // ---------------------------------------------------------------------------
 
-export const shouldSkipValidate = function (options: ValidateOptions, errors: any) {
-  return (
-    options &&
-    Array.isArray(options.includeErrors) &&
-    options.includeErrors.length > 0 &&
-    !errors.some(function (err: any) {
-      return options.includeErrors!.includes(err);
-    })
-  );
-};
+export const shouldSkipValidate = (options: ValidateOptions, errors: any) =>
+  options &&
+  Array.isArray(options.includeErrors) &&
+  options.includeErrors.length > 0 &&
+  !errors.some((err: any) => options.includeErrors!.includes(err));
 
 export const supportsDependentKeywords = (
   schema: JsonSchemaInternal,

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -306,7 +306,7 @@ export class ZSchemaBase {
     const visited = new WeakSet<object>();
 
     // clean-up the schema and resolve references
-    const cleanup = function (schema: any) {
+    const cleanup = (schema: any) => {
       let key;
       const typeOf = whatIs(schema);
       if (typeOf !== 'object' && typeOf !== 'array') {

--- a/test/ZSchemaTestSuite/Issue85.ts
+++ b/test/ZSchemaTestSuite/Issue85.ts
@@ -9,7 +9,7 @@ const originalSchema = {
   },
 };
 
-const getKeys = function (obj: any) {
+const getKeys = (obj: any) => {
   const arr: string[] = [];
   for (const key in obj) {
     if (Object.hasOwn(obj, key)) {


### PR DESCRIPTION
## Summary

Reorganizes `oxlint.config.ts` to separate intentional project rule overrides from the TODO backlog of preset rules still reporting errors.

- Promotes `func-style`, `no-inline-comments`, `no-plusplus`, `require-unicode-regexp`, `sort-keys`, `typescript/no-non-null-assertion`, and `unicorn/prefer-node-protocol` into the intentional-overrides block.
- `func-style` is now configured as `['error', 'declaration', { allowArrowFunctions: true }]` rather than disabled.
- Removes the corresponding verbose TODO comment blocks now that these rules are intentionally settled.

## Test plan

- `npm run check` (lint + format) — pre-commit hooks pass