### PR TITLE
chore: re-enable 10 auto-fixable oxlint rules from the TODO backlog

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -12,7 +12,7 @@ Line coverage status: **high**
 | src/json-schema.ts            |     98% |         98% |       100% |      98% |
 | src/json-validation.ts        |     91% |         91% |        97% |      91% |
 | src/report.ts                 |     94% |         95% |        95% |      88% |
-| src/schema-cache.ts           |     89% |         90% |        92% |      89% |
+| src/schema-cache.ts           |     90% |         90% |        92% |      89% |
 | src/schema-compiler.ts        |     94% |         94% |       100% |      90% |
 | src/schema-validator.ts       |     81% |         81% |       100% |      77% |
 | src/utils/array.ts            |    100% |        100% |       100% |     100% |
@@ -28,7 +28,7 @@ Line coverage status: **high**
 | src/utils/time.ts             |     97% |         97% |       100% |      95% |
 | src/utils/unicode.ts          |    100% |        100% |       100% |     100% |
 | src/utils/uri.ts              |     90% |         91% |        75% |     100% |
-| src/utils/what-is.ts          |     83% |         83% |       100% |      85% |
+| src/utils/what-is.ts          |     81% |         81% |       100% |      85% |
 | src/validation/array.ts       |     92% |         93% |       100% |      91% |
 | src/validation/combinators.ts |     96% |         96% |       100% |      93% |
 | src/validation/numeric.ts     |     87% |         87% |       100% |      89% |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -115,14 +115,6 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 18
-    // complexity: trivial
-    // Caught error variables are not named `error` or `err` as the rule requires; renaming is mechanical.
-    // type: style
-    // Requires caught error variables in `catch` clauses to follow a consistent naming convention (e.g., `error`).
-    'unicorn/catch-error-name': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 18
     // complexity: dangerous
     // Expressions are used in boolean positions without explicit comparison; fixing requires auditing each site for nullable/falsy semantics.
     // type: type-safety
@@ -208,14 +200,6 @@ export default defineConfig({
     // type: style
     // Disallows negated conditions in `if/else` statements when reordering branches would remove the negation.
     'no-negated-condition': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 11
-    // complexity: trivial
-    // String encoding identifiers like `"utf-8"` are used instead of the canonical `"utf8"` form (or vice-versa).
-    // type: style
-    // Enforces a consistent casing/form for text encoding identifier strings (e.g., `"utf8"` vs `"utf-8"`).
-    'unicorn/text-encoding-identifier-case': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 11
@@ -307,22 +291,6 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 3
-    // complexity: trivial
-    // `if/else` returning values can be collapsed into a ternary expression; mechanical transformation.
-    // type: style
-    // Prefers ternary expressions over simple `if/else` blocks that only return or assign a value.
-    'unicorn/prefer-ternary': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
-    // complexity: easy
-    // Index existence checks (e.g., `arr.indexOf(x) !== -1`) are written in an inconsistent form; normalising requires auditing intent.
-    // type: style
-    // Enforces a consistent style for checking whether an element exists in an array by index comparison.
-    'unicorn/consistent-existence-index-check': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
     // complexity: moderate
     // Functions that return a `Promise` are not marked `async`; adding `async` changes the error-handling behaviour for thrown exceptions.
     // type: best-practice
@@ -344,14 +312,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows returning `any`-typed values from functions with non-`any` return type annotations.
     'typescript/no-unsafe-return': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
-    // complexity: trivial
-    // Comparisons like `flag === true` or `flag === false` are written where `flag` or `!flag` suffice.
-    // type: style
-    // Disallows unnecessary comparisons of boolean values to boolean literals (`=== true`, `=== false`).
-    'typescript/no-unnecessary-boolean-literal-compare': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 3
@@ -474,14 +434,6 @@ export default defineConfig({
     'no-promise-executor-return': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: trivial
-    // `if/else` blocks end with a `return`, making the `else` branch redundant; removing `else` is mechanical.
-    // type: style
-    // Disallows `else` blocks after `if` blocks that always return, requiring early returns instead.
-    'no-else-return': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
     // complexity: trivial
     // An array is used for membership testing (`arr.includes(x)`) where a `Set` would have O(1) lookup.
@@ -496,14 +448,6 @@ export default defineConfig({
     // type: style
     // Prefers `Array.prototype.includes()` over `indexOf` comparisons for readability.
     'unicorn/prefer-includes': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // A spread contains a fallback (`x || []`) that is unnecessary because spreading `undefined` or `null` is already safe.
-    // type: style
-    // Disallows useless fallback values in spread expressions when spreading `undefined`/`null` is already a no-op.
-    'unicorn/no-useless-fallback-in-spread': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
@@ -580,14 +524,6 @@ export default defineConfig({
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
     // complexity: trivial
-    // Bracket notation (`obj['key']`) is used where dot notation (`obj.key`) would be valid; mechanical substitution.
-    // type: style
-    // Requires dot notation for property access when the property name is a valid identifier.
-    'typescript/dot-notation': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
     // Generic constructor calls use type argument on the left side (`new Map<string, string>()`) where the right side or inference is preferred (or vice-versa).
     // type: style
     // Enforces a consistent location for type arguments in generic constructor calls (`new Foo<T>()` vs `Foo<T> = new Foo()`).
@@ -612,14 +548,6 @@ export default defineConfig({
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
     // complexity: trivial
-    // The same module is imported more than once; merging into a single import statement is mechanical.
-    // type: style
-    // Disallows duplicate `import` statements for the same module, requiring them to be consolidated.
-    'import/no-duplicates': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
     // Multiple variable declarations in a single `var`/`let`/`const` statement are not sorted alphabetically.
     // type: style
     // Requires variables declared in the same statement to be sorted alphabetically.
@@ -632,14 +560,6 @@ export default defineConfig({
     // type: style
     // Prefers regex literals over `new RegExp()` when the pattern is a static string literal.
     'prefer-regex-literals': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // A ternary expression has redundant boolean operands (e.g., `x ? true : false`); simplifying to `!!x` or `x` is mechanical.
-    // type: style
-    // Disallows ternary operators where a simpler non-ternary expression would produce the same result.
-    'no-unneeded-ternary': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1

--- a/scripts/coverage-update-utils.mts
+++ b/scripts/coverage-update-utils.mts
@@ -22,7 +22,7 @@ const trackedCoverageFiles = ['docs/test-coverage.md', 'README.md'];
 export function getChangedTrackedFiles(cwd = process.cwd(), trackedFiles = trackedCoverageFiles): string[] {
   const output = execFileSync('git', ['status', '--porcelain', '--untracked-files=no', '--', ...trackedFiles], {
     cwd,
-    encoding: 'utf8',
+    encoding: 'utf-8',
   });
 
   const changed = new Set<string>();
@@ -88,7 +88,7 @@ export function isForkPullRequest(githubEventPath: string | undefined, repositor
   }
 
   const safeEventPath = safePath(githubEventPath);
-  const payload = JSON.parse(readFileSync(safeEventPath, 'utf8')) as PullRequestPayload;
+  const payload = JSON.parse(readFileSync(safeEventPath, 'utf-8')) as PullRequestPayload;
   const headRepo = payload.pull_request?.head?.repo?.full_name;
 
   if (!headRepo) {

--- a/scripts/generate-test-coverage-report.mts
+++ b/scripts/generate-test-coverage-report.mts
@@ -101,7 +101,7 @@ export function parseCoverageSummary(summary: CoverageSummaryFile, repoRoot = pr
 
 export function readCoverageSummary(coverageDir = 'coverage', repoRoot = process.cwd()): ParsedCoverageSummary {
   const coverageSummaryPath = join(coverageDir, 'coverage-summary.json');
-  const raw = readFileSync(coverageSummaryPath, 'utf8');
+  const raw = readFileSync(coverageSummaryPath, 'utf-8');
   const parsed = JSON.parse(raw) as CoverageSummaryFile;
 
   return parseCoverageSummary(parsed, repoRoot);
@@ -138,7 +138,7 @@ function writeFileIfChanged(filePath: string, content: string): boolean {
   let original = '';
 
   try {
-    original = readFileSync(filePath, 'utf8');
+    original = readFileSync(filePath, 'utf-8');
   } catch {
     original = '';
   }
@@ -148,7 +148,7 @@ function writeFileIfChanged(filePath: string, content: string): boolean {
   }
 
   mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, content, 'utf8');
+  writeFileSync(filePath, content, 'utf-8');
   return true;
 }
 

--- a/scripts/update-readme-coverage-badge.mts
+++ b/scripts/update-readme-coverage-badge.mts
@@ -76,14 +76,14 @@ export function updateReadmeCoverageBadge(readmeContent: string, linePct: number
 
 export function updateReadmeCoverageBadgeFile(readmePath: string, linePct: number): boolean {
   const safeReadmePath = safePath(readmePath, process.cwd());
-  const original = readFileSync(safeReadmePath, 'utf8');
+  const original = readFileSync(safeReadmePath, 'utf-8');
   const updated = updateReadmeCoverageBadge(original, linePct);
 
   if (updated === original) {
     return false;
   }
 
-  writeFileSync(safeReadmePath, updated, 'utf8');
+  writeFileSync(safeReadmePath, updated, 'utf-8');
   return true;
 }
 

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -224,15 +224,15 @@ const uriValidator: FormatValidatorFn = (uri: unknown) => {
       }
     }
     // Validate port: must be numeric
-    let hostPort = atIndex >= 0 ? authority.slice(atIndex + 1) : authority;
+    let hostPort = atIndex !== -1 ? authority.slice(atIndex + 1) : authority;
     if (hostPort.startsWith('[')) {
       const bracketEnd = hostPort.indexOf(']');
-      if (bracketEnd >= 0) {
+      if (bracketEnd !== -1) {
         hostPort = hostPort.slice(bracketEnd + 1);
       }
     }
     const colonIndex = hostPort.lastIndexOf(':');
-    if (colonIndex >= 0) {
+    if (colonIndex !== -1) {
       const port = hostPort.slice(colonIndex + 1);
       if (port.length > 0 && !/^\d+$/.test(port)) {
         return false;
@@ -425,7 +425,7 @@ export function getFormatValidators(options?: FormatValidatorsOptions): Record<s
     ...inbuiltValidators,
     ...(options?.strictUris ? { uri: strictUriValidator } : {}),
     ...customValidators,
-    ...(options?.customFormats || {}),
+    ...options?.customFormats,
   };
 }
 

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -647,7 +647,7 @@ function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInte
     // 2. For each regex in "pp", if it matches "m" successfully, the corresponding schema in "patternProperties" is added to "s".
     for (const regexString of pp) {
       const result = compileSchemaRegex(regexString);
-      if (result.ok && result.value.test(m) === true) {
+      if (result.ok && result.value.test(m)) {
         s.push(schema.patternProperties![regexString]);
       }
     }

--- a/src/schema-cache.ts
+++ b/src/schema-cache.ts
@@ -43,13 +43,8 @@ export function prepareRemoteSchema(
   validationOptions?: ZSchemaOptions,
   maxCloneDepth?: number
 ): JsonSchemaInternal {
-  let _schema: JsonSchemaInternal;
-
-  if (typeof schema === 'string') {
-    _schema = JSON.parse(schema);
-  } else {
-    _schema = deepClone(schema, maxCloneDepth);
-  }
+  const _schema: JsonSchemaInternal =
+    typeof schema === 'string' ? JSON.parse(schema) : deepClone(schema, maxCloneDepth);
 
   if (!_schema.id) {
     _schema.id = uri;
@@ -190,7 +185,7 @@ export class SchemaCache {
           usesAncestorReport = true;
         } else {
           remoteReport = new Report(report);
-          const noCache = result.id && isAbsoluteUri(result.id) ? false : true;
+          const noCache = !(result.id && isAbsoluteUri(result.id));
           if (this.validator.sc.compileSchema(remoteReport, result, { noCache })) {
             const savedOptions = this.validator.options;
             try {
@@ -231,6 +226,7 @@ export class SchemaCache {
       const parts = queryPath.split('/');
       for (let idx = 0, lim = parts.length; result && idx < lim; idx++) {
         const key = decodeJSONPointer(parts[idx]);
+        // oxlint-disable-next-line unicorn/prefer-ternary
         if (idx === 0) {
           // it's an id
           result = findId(result, key, remotePath, remotePath, this.validator.options.maxRecursionDepth);

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -322,10 +322,9 @@ export class SchemaCompiler {
       return this.compileArrayOfSchemas(report, schema);
     } else if (typeof schema === 'boolean') {
       return true;
-    } else {
-      if (!options?.noCache) {
-        this.collectAndCacheIds(schema);
-      }
+    }
+    if (!options?.noCache) {
+      this.collectAndCacheIds(schema);
     }
 
     const canMutateSchemaObject =
@@ -338,7 +337,7 @@ export class SchemaCompiler {
       canMutateSchemaObject &&
       schema.__$compiled &&
       schema.id &&
-      this.validator.scache.checkCacheForUri(schema.id) === false
+      !this.validator.scache.checkCacheForUri(schema.id)
     ) {
       schema.__$compiled = undefined;
     }

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -244,7 +244,7 @@ const SchemaValidators = {
           report.addError('KEYWORD_VALUE_TYPE', ['required', 'string'], undefined, schema, 'required');
         }
       }
-      if (isUniqueArray(schema.required) === false) {
+      if (!isUniqueArray(schema.required)) {
         report.addError('KEYWORD_MUST_BE', ['required', 'an array with unique items'], undefined, schema, 'required');
       }
     }
@@ -356,7 +356,7 @@ const SchemaValidators = {
               report.addError('KEYWORD_VALUE_TYPE', ['dependencies', 'string'], undefined, schema, 'dependencies');
             }
           }
-          if (isUniqueArray(depArray) === false) {
+          if (!isUniqueArray(depArray)) {
             report.addError(
               'KEYWORD_MUST_BE',
               ['dependencies', 'an array with unique items'],
@@ -379,11 +379,11 @@ const SchemaValidators = {
   },
   enum(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.1.1
-    if (Array.isArray(schema.enum) === false) {
+    if (!Array.isArray(schema.enum)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['enum', 'array'], undefined, schema, 'enum');
     } else if (schema.enum.length === 0) {
       report.addError('KEYWORD_MUST_BE', ['enum', 'an array with at least one element'], undefined, schema, 'enum');
-    } else if (isUniqueArray(schema.enum) === false) {
+    } else if (!isUniqueArray(schema.enum)) {
       report.addError('KEYWORD_MUST_BE', ['enum', 'an array with unique elements'], undefined, schema, 'enum');
     }
   },
@@ -399,7 +399,7 @@ const SchemaValidators = {
           report.addError('KEYWORD_TYPE_EXPECTED', ['type', primitiveTypeStr], undefined, schema, 'type');
         }
       }
-      if (isUniqueArray(schema.type) === false) {
+      if (!isUniqueArray(schema.type)) {
         report.addError('KEYWORD_MUST_BE', ['type', 'an object with unique properties'], undefined, schema, 'type');
       }
     } else if (typeof schema.type === 'string') {
@@ -478,7 +478,7 @@ const SchemaValidators = {
   },
   allOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.3.1
-    if (Array.isArray(schema.allOf) === false) {
+    if (!Array.isArray(schema.allOf)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['allOf', 'array'], undefined, schema, 'allOf');
     } else if (schema.allOf.length === 0) {
       report.addError('KEYWORD_MUST_BE', ['allOf', 'an array with at least one element'], undefined, schema, 'allOf');
@@ -494,7 +494,7 @@ const SchemaValidators = {
   },
   anyOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.4.1
-    if (Array.isArray(schema.anyOf) === false) {
+    if (!Array.isArray(schema.anyOf)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['anyOf', 'array'], undefined, schema, 'anyOf');
     } else if (schema.anyOf.length === 0) {
       report.addError('KEYWORD_MUST_BE', ['anyOf', 'an array with at least one element'], undefined, schema, 'anyOf');
@@ -510,7 +510,7 @@ const SchemaValidators = {
   },
   oneOf(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.5.1
-    if (Array.isArray(schema.oneOf) === false) {
+    if (!Array.isArray(schema.oneOf)) {
       report.addError('KEYWORD_TYPE_EXPECTED', ['oneOf', 'array'], undefined, schema, 'oneOf');
     } else if (schema.oneOf.length === 0) {
       report.addError('KEYWORD_MUST_BE', ['oneOf', 'an array with at least one element'], undefined, schema, 'oneOf');
@@ -727,7 +727,7 @@ export class SchemaValidator {
       if (schema.__$schemaResolved && schema.__$schemaResolved !== schema) {
         const subReport = new Report(report);
         const valid = validate.call(this.validator, subReport, schema.__$schemaResolved, schema);
-        if (valid === false) {
+        if (!valid) {
           report.addError('PARENT_SCHEMA_VALIDATION_FAILED', undefined, subReport, schema, '$schema');
         }
       } else if (this.validator.options.ignoreUnresolvableReferences !== true) {

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -22,7 +22,7 @@ export const decodeBase64 = (value: string): string | undefined => {
 
   if (typeof Buffer !== 'undefined') {
     try {
-      return Buffer.from(value, 'base64').toString('utf8');
+      return Buffer.from(value, 'base64').toString('utf-8');
     } catch {
       return undefined;
     }

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -21,7 +21,7 @@ export const areEqual = (json1: unknown, json2: unknown, options?: AreEqualOptio
     return true;
   }
   if (
-    caseInsensitiveComparison === true &&
+    caseInsensitiveComparison &&
     typeof json1 === 'string' &&
     typeof json2 === 'string' &&
     json1.toUpperCase() === json2.toUpperCase()

--- a/src/utils/schema-regex.ts
+++ b/src/utils/schema-regex.ts
@@ -40,12 +40,12 @@ export function compileSchemaRegex(
     try {
       const re = new RegExp(pattern, 'u');
       return { ok: true, value: re };
-    } catch (e: any) {
+    } catch (error: any) {
       return {
         ok: false,
         error: {
           pattern,
-          message: e && e.message ? e.message : 'Invalid regular expression',
+          message: error && error.message ? error.message : 'Invalid regular expression',
         },
       };
     }
@@ -53,12 +53,12 @@ export function compileSchemaRegex(
     try {
       const re = new RegExp(pattern);
       return { ok: true, value: re };
-    } catch (e: any) {
+    } catch (error: any) {
       return {
         ok: false,
         error: {
           pattern,
-          message: e && e.message ? e.message : 'Invalid regular expression',
+          message: error && error.message ? error.message : 'Invalid regular expression',
         },
       };
     }

--- a/src/utils/what-is.ts
+++ b/src/utils/what-is.ts
@@ -26,11 +26,7 @@ export const whatIs = (what: unknown): WHAT_IS => {
 
   if (typeof what === 'number') {
     if (Number.isFinite(what)) {
-      if (what % 1 === 0) {
-        return 'integer';
-      } else {
-        return 'number';
-      }
+      return what % 1 === 0 ? 'integer' : 'number';
     }
     if (Number.isNaN(what)) {
       return 'not-a-number';

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -89,7 +89,7 @@ export function uniqueItemsValidator(this: ZSchemaBase, report: Report, schema: 
   }
   if (schema.uniqueItems === true) {
     const matches: any[] = [];
-    if (isUniqueArray(json, matches, this.options.maxRecursionDepth) === false) {
+    if (!isUniqueArray(json, matches, this.options.maxRecursionDepth)) {
       report.addError('ARRAY_UNIQUE', matches, undefined, schema, 'uniqueItems');
     }
   }

--- a/src/validation/combinators.ts
+++ b/src/validation/combinators.ts
@@ -12,7 +12,7 @@ export function allOfValidator(this: ZSchemaBase, report: Report, schema: JsonSc
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.3.2
   for (let i = 0; i < schema.allOf!.length; i++) {
     const validateResult = this._jsonValidate(report, schema.allOf![i], json);
-    if (this.options.breakOnFirstError && validateResult === false) {
+    if (this.options.breakOnFirstError && !validateResult) {
       break;
     }
   }
@@ -43,7 +43,7 @@ export function anyOfValidator(this: ZSchemaBase, report: Report, schema: JsonSc
       }
     }
 
-    if (passed === false) {
+    if (!passed) {
       report.addError('ANY_OF_MISSING', undefined, subReports, schema, 'anyOf');
     }
   });
@@ -88,7 +88,7 @@ export function oneOfValidator(this: ZSchemaBase, report: Report, schema: JsonSc
 export function notValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.6.2
   const subReport = new Report(report);
-  if (this._jsonValidate(subReport, schema.not!, json) === true) {
+  if (this._jsonValidate(subReport, schema.not!, json)) {
     report.addError('NOT_PASSED', undefined, undefined, schema, 'not');
   }
 }

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -139,7 +139,7 @@ export function propertiesValidator(this: ZSchemaBase, report: Report, schema: J
       }
       const regExp = result.value;
       for (let idx2 = s.length - 1; idx2 >= 0; idx2--) {
-        if (regExp.test(s[idx2]) === true) {
+        if (regExp.test(s[idx2])) {
           s.splice(idx2, 1);
         }
       }

--- a/src/validation/shared.ts
+++ b/src/validation/shared.ts
@@ -89,7 +89,7 @@ export const isValidationVocabularyEnabled = (
   const has2020 = Object.hasOwn(vocabulary, VOCAB_VALIDATION_2020_12);
 
   if (has2019 || has2020) {
-    return vocabulary[VOCAB_VALIDATION_2019_09] === true || vocabulary[VOCAB_VALIDATION_2020_12] === true;
+    return vocabulary[VOCAB_VALIDATION_2019_09] || vocabulary[VOCAB_VALIDATION_2020_12];
   }
 
   return false;
@@ -123,12 +123,12 @@ export const isFormatAssertionVocabEnabled = (
 
   // For draft 2020-12, only the format-assertion vocabulary enables format as assertion
   if (Object.hasOwn(vocabulary, VOCAB_FORMAT_ASSERTION_2020_12)) {
-    return vocabulary[VOCAB_FORMAT_ASSERTION_2020_12] === true;
+    return vocabulary[VOCAB_FORMAT_ASSERTION_2020_12];
   }
 
   // For draft 2019-09, check if the format vocabulary is enabled (true)
   if (Object.hasOwn(vocabulary, VOCAB_FORMAT_2019_09)) {
-    return vocabulary[VOCAB_FORMAT_2019_09] === true;
+    return vocabulary[VOCAB_FORMAT_2019_09];
   }
 
   return false; // default to annotation-only for modern drafts

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -122,7 +122,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
             }
           }
         );
-      } else if (result !== true) {
+      } else if (!result) {
         // sync
         report.addError('INVALID_FORMAT', [schema.format!, JSON.stringify(json)], undefined, schema, 'format');
       }

--- a/src/validation/type.ts
+++ b/src/validation/type.ts
@@ -45,7 +45,7 @@ export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSch
     }
   }
 
-  if (match === false) {
+  if (!match) {
     const error =
       caseInsensitiveMatch && this.options.enumCaseInsensitiveComparison ? 'ENUM_CASE_MISMATCH' : 'ENUM_MISMATCH';
     report.addError(error, [JSON.stringify(json)], undefined, schema, 'enum');
@@ -58,7 +58,7 @@ export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSch
 
 export function constValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   const constValue = schema.const;
-  if (areEqual(json, constValue, { maxDepth: this.options.maxRecursionDepth }) === false) {
+  if (!areEqual(json, constValue, { maxDepth: this.options.maxRecursionDepth })) {
     report.addError('CONST', [JSON.stringify(constValue)], undefined, schema);
   }
 }

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -1,10 +1,9 @@
-import type { ValidateError } from './errors.js';
 import type { FormatValidatorFn } from './format-validators.js';
 import type { JsonSchema, JsonSchemaInternal, JsonSchemaVersion } from './json-schema-versions.js';
 import type { SchemaErrorDetail } from './report.js';
 import type { ZSchemaOptions } from './z-schema-options.js';
 
-import { type Errors, getValidateError } from './errors.js';
+import { type Errors, type ValidateError, getValidateError } from './errors.js';
 import { getSupportedFormats } from './format-validators.js';
 import { VERSION_SCHEMA_URL_MAPPING } from './json-schema-versions.js';
 import { isInternalKey } from './json-schema.js';

--- a/src/z-schema.ts
+++ b/src/z-schema.ts
@@ -148,8 +148,8 @@ export class ZSchema extends ZSchemaBase {
     try {
       this._validate(json, schema, options ?? {});
       return { valid: true };
-    } catch (err) {
-      return { valid: false, err: err as ValidateError };
+    } catch (error) {
+      return { valid: false, err: error as ValidateError };
     }
   }
 
@@ -164,11 +164,9 @@ export class ZSchema extends ZSchemaBase {
   validateAsync(json: unknown, schema: JsonSchema | string, options?: ValidateOptions): Promise<true> {
     return new Promise((resolve, reject) => {
       try {
-        this._validate(json, schema, options || {}, (err, valid) =>
-          err || valid !== true ? reject(err) : resolve(valid)
-        );
-      } catch (err) {
-        reject(err);
+        this._validate(json, schema, options || {}, (err, valid) => (err || !valid ? reject(err) : resolve(valid)));
+      } catch (error) {
+        reject(error);
       }
     });
   }
@@ -187,8 +185,8 @@ export class ZSchema extends ZSchemaBase {
         this._validate(json, schema, options || {}, (err, valid) => {
           resolve({ valid, err });
         });
-      } catch (err) {
-        resolve({ valid: false, err: err as ValidateError });
+      } catch (error) {
+        resolve({ valid: false, err: error as ValidateError });
       }
     });
   }
@@ -212,8 +210,8 @@ export class ZSchema extends ZSchemaBase {
     try {
       this._validateSchema(schemaOrArr);
       return { valid: true };
-    } catch (err) {
-      return { valid: false, err: err as ValidateError };
+    } catch (error) {
+      return { valid: false, err: error as ValidateError };
     }
   }
 }
@@ -239,8 +237,8 @@ export class ZSchemaSafe extends ZSchemaBase {
     try {
       this._validate(json, schema, options);
       return { valid: true };
-    } catch (err) {
-      return { valid: false, err: err as ValidateError };
+    } catch (error) {
+      return { valid: false, err: error as ValidateError };
     }
   }
 
@@ -253,8 +251,8 @@ export class ZSchemaSafe extends ZSchemaBase {
     try {
       this._validateSchema(schemaOrArr);
       return { valid: true };
-    } catch (err) {
-      return { valid: false, err: err as ValidateError };
+    } catch (error) {
+      return { valid: false, err: error as ValidateError };
     }
   }
 }
@@ -280,9 +278,9 @@ export class ZSchemaAsync extends ZSchemaBase {
   validate(json: unknown, schema: JsonSchema | string, options: ValidateOptions = {}): Promise<true> {
     return new Promise((resolve, reject) => {
       try {
-        this._validate(json, schema, options, (err, valid) => (err || valid !== true ? reject(err) : resolve(valid)));
-      } catch (err) {
-        reject(err);
+        this._validate(json, schema, options, (err, valid) => (err || !valid ? reject(err) : resolve(valid)));
+      } catch (error) {
+        reject(error);
       }
     });
   }
@@ -322,8 +320,8 @@ export class ZSchemaAsyncSafe extends ZSchemaBase {
         this._validate(json, schema, options, (err, valid) => {
           resolve({ valid, err });
         });
-      } catch (err) {
-        resolve({ valid: false, err: err as ValidateError });
+      } catch (error) {
+        resolve({ valid: false, err: error as ValidateError });
       }
     });
   }
@@ -337,8 +335,8 @@ export class ZSchemaAsyncSafe extends ZSchemaBase {
     try {
       this._validateSchema(schemaOrArr);
       return { valid: true };
-    } catch (err) {
-      return { valid: false, err: err as ValidateError };
+    } catch (error) {
+      return { valid: false, err: error as ValidateError };
     }
   }
 }

--- a/test/spec/cli-smoke.node-spec.ts
+++ b/test/spec/cli-smoke.node-spec.ts
@@ -6,7 +6,7 @@ describe('CLI smoke', function () {
     const res = child.spawnSync(
       process.execPath,
       ['bin/z-schema', 'test/fixtures/sample-schema.json', 'test/fixtures/sample-valid.json'],
-      { encoding: 'utf8' }
+      { encoding: 'utf-8' }
     );
     expect(res.status).toBe(0);
     expect(res.stdout || res.stderr).toMatch(/validation passed/i);
@@ -16,7 +16,7 @@ describe('CLI smoke', function () {
     const res = child.spawnSync(
       process.execPath,
       ['bin/z-schema', 'test/fixtures/sample-schema.json', 'test/fixtures/sample-valid.json'],
-      { encoding: 'utf8' }
+      { encoding: 'utf-8' }
     );
     expect(res.status).toBe(0);
     expect(res.stdout).toMatch(/sample-valid\.json validation passed/);
@@ -29,7 +29,7 @@ describe('CLI smoke', function () {
     const res = child.spawnSync(
       process.execPath,
       ['bin/z-schema', 'test/fixtures/sample-schema.json', absoluteValid, nestedValid],
-      { encoding: 'utf8' }
+      { encoding: 'utf-8' }
     );
     expect(res.status).toBe(0);
     expect(res.stdout).not.toContain(absoluteValid);

--- a/test/spec/default-version.spec.ts
+++ b/test/spec/default-version.spec.ts
@@ -6,6 +6,6 @@ describe('default behavior', () => {
     const s = { id: 'hello' };
     expect(() => validator.validateSchema(s)).not.toThrow();
     expect(s).toEqual({ id: 'hello' });
-    expect(validator.scache.cache['hello'].$schema).toEqual(validator.getDefaultSchemaId());
+    expect(validator.scache.cache.hello.$schema).toEqual(validator.getDefaultSchemaId());
   });
 });

--- a/test/spec/schema-path.spec.ts
+++ b/test/spec/schema-path.spec.ts
@@ -94,8 +94,7 @@ describe('Schema path tracking in validation errors', function () {
     try {
       validator.validate(data, schema);
       expect.fail('Validation should have failed');
-    } catch (err) {
-      const error = err as any;
+    } catch (error: any) {
       expect(error.details).toHaveLength(1);
       expect(error.details[0].path).toEqual(['age']);
       expect(error.details[0].schemaPath).toEqual(['properties', 'age', 'type']);
@@ -113,8 +112,7 @@ describe('Schema path tracking in validation errors', function () {
     try {
       validator.validate(data, schema);
       expect.fail('Validation should have failed');
-    } catch (err) {
-      const error = err as any;
+    } catch (error: any) {
       expect(error.details).toHaveLength(1);
       expect(error.details[0].path).toEqual([1]);
       expect(error.details[0].schemaPath).toEqual(['items', 'type']);
@@ -140,8 +138,7 @@ describe('Schema path tracking in validation errors', function () {
     try {
       validator.validate(data, schema);
       expect.fail('Validation should have failed');
-    } catch (err) {
-      const error = err as any;
+    } catch (error: any) {
       expect(error.details).toHaveLength(1);
       expect(error.details[0].path).toEqual(['user', 'age']);
       expect(error.details[0].schemaPath).toEqual(['properties', 'user', 'properties', 'age', 'type']);
@@ -156,8 +153,7 @@ describe('Schema path tracking in validation errors', function () {
     try {
       validator.validate(data, schema);
       expect.fail('Validation should have failed');
-    } catch (err) {
-      const error = err as any;
+    } catch (error: any) {
       expect(error.details).toHaveLength(1);
       expect(error.details[0].path).toEqual([]);
       expect(error.details[0].schemaPath).toEqual(['type']);
@@ -186,8 +182,7 @@ describe('Schema path tracking in validation errors', function () {
     try {
       validator.validate(data, schema);
       expect.fail('Validation should have failed');
-    } catch (err) {
-      const error = err as any;
+    } catch (error: any) {
       expect(error.details).toHaveLength(1);
       expect(error.details[0].path).toEqual(['user', 'age']);
       expect(error.details[0].schemaPath).toEqual(['properties', 'user', 'properties', 'age', 'type']);

--- a/test/spec/unicode-pattern.spec.ts
+++ b/test/spec/unicode-pattern.spec.ts
@@ -5,7 +5,7 @@ import { ZSchema } from '../../src/z-schema.ts';
 function supportsUnicodePropertyEscapes() {
   try {
     const re = new RegExp('^\\p{L}+$', 'u');
-    return re.test('abc') === true;
+    return re.test('abc');
   } catch {
     return false;
   }

--- a/test/spec/z-schema-test-suite.spec.ts
+++ b/test/spec/z-schema-test-suite.spec.ts
@@ -159,7 +159,7 @@ describe('ZSchemaTestSuite', function () {
 
           expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
           expect(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
-          if (test.valid === true) {
+          if (test.valid) {
             expect(err).toBe(undefined /*, 'errors are not undefined when test is valid'*/);
           }
           if (after) {
@@ -181,11 +181,11 @@ describe('ZSchemaTestSuite', function () {
         try {
           validator.validateSchema(schema as any);
           valid = true;
-        } catch (err) {
+        } catch (error) {
           if (!failWithException) {
             valid = false;
           }
-          caughtErr = err;
+          caughtErr = error;
         }
 
         if (valid && !validateSchemaOnly) {
@@ -194,9 +194,9 @@ describe('ZSchemaTestSuite', function () {
           }
           try {
             valid = validator.validate(data, schema as any, validateOptions as any);
-          } catch (err) {
+          } catch (error) {
             valid = false;
-            caughtErr = err;
+            caughtErr = error;
           }
         }
 
@@ -209,7 +209,7 @@ describe('ZSchemaTestSuite', function () {
           expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
         }
 
-        if (test.valid === true) {
+        if (test.valid) {
           expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
         }
 


### PR DESCRIPTION
## Summary

Continues the incremental oxlint TODO backlog burndown (cf. #414, #416). Re-enables 10 low-risk, predominantly auto-fixable rules from the `oxlint.config.ts` TODO section and fixes the resulting violations.

## Rules re-enabled

| Rule | Sites | Fix |
|------|-------|-----|
| `typescript/dot-notation` | 0 | no-op (already clean) |
| `import/no-duplicates` | 1 | merge duplicate import |
| `unicorn/no-useless-fallback-in-spread` | 1 | drop `|| {}` fallback |
| `no-unneeded-ternary` | 1 | boolean inversion |
| `unicorn/text-encoding-identifier-case` | 7 | normalize `'utf8'` → `'utf-8'` (scripts) |
| `unicorn/consistent-existence-index-check` | 3 | `>= 0` → `!== -1` |
| `no-else-return` | 2 | early return |
| `unicorn/prefer-ternary` | 3 | ternary (1 site suppressed to keep branch comments) |
| `unicorn/catch-error-name` | 11 | rename catch binding to `error` |
| `typescript/no-unnecessary-boolean-literal-compare` | 26 | `x === true`→`x`, `x === false`→`!x` |

Deliberately left in the backlog: `eqeqeq`/`no-eq-null` (redundant pair, load-bearing `== null` guards), `no-negated-condition` (manual branch swaps), `prefer-spread`/`prefer-destructuring` (only partial auto-fix).

## Notes

- One site (`src/schema-cache.ts`) keeps its `if/else` with an inline `// oxlint-disable-next-line unicorn/prefer-ternary` to preserve explanatory branch comments — matches the intentional-override pattern from #415.
- `test/spec/schema-path.spec.ts`: the catch-binding rename collided with an existing `const error = error as any` redeclaration; resolved by annotating the catch binding (`catch (error: any)`) and dropping the redundant cast.
- No public API / option / error-code / format-validator surface changes, so no docs updates required.

## Verification

- `npm run check` — clean (lint + format)
- `npm run build` + `npm run build:tests` — pass
- `npm test` — 32,389 tests pass (node + browser)