### PR TITLE
chore: re-enable 10 auto-fixable oxlint rules from the TODO backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,20 @@ See [docs/conventions.md](docs/conventions.md) for details.
 
 All public methods and classes **must** have [TSDoc](https://tsdoc.org/) comments. When adding or modifying public API surface, update TSDoc accordingly. Do not use JSDoc-style type annotations — rely on TypeScript for types. See the conventions doc for the full TSDoc style guide.
 
+## Performance
+
+**Performance is a primary, non-negotiable goal of this library.** z-schema validates JSON on hot paths that run millions of times — small per-call costs compound. Correctness and readability matter, but **never trade away performance for stylistic sugar when a faster equivalent exists.**
+
+Concrete rules:
+
+- **Never replace a faster construct with a slower one for style reasons.** In particular:
+  - Prefer `Array.prototype.concat` / `Array.prototype.slice` over the spread operator (`[...a, ...b]`, `[...a]`). Spread allocates via the iterator protocol and is measurably slower in V8 hot paths.
+  - Prefer index-based `for` loops over `for…of` in validation hot paths. `for…of` adds iterator-protocol overhead versus direct indexed access.
+  - Prefer `Set`/`Map` lookups (`O(1)`) over repeated `Array.prototype.includes`/`indexOf` (`O(n)`) on frequently-queried collections.
+- Avoid unnecessary allocations (intermediate arrays/objects, closures) inside per-keyword and per-element validation loops.
+- Some lint rules that would push code toward the slower form are **intentionally kept `off`** in [oxlint.config.ts](oxlint.config.ts) under the "Intentionally kept off for performance" block (e.g. `unicorn/prefer-spread`, `typescript/prefer-for-of`). Do not re-enable them, and do not silence the resulting wins by hand-applying their fixes.
+- If a change might affect performance, benchmark it and call out the result in the PR. When in doubt, favor the faster construct.
+
 ## Testing Guide
 
 See [docs/testing.md](docs/testing.md) for details.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -30,6 +30,18 @@ export default defineConfig({
     'typescript/no-non-null-assertion': 'off',
     'unicorn/prefer-node-protocol': 'off',
 
+    // ── Intentionally kept off for performance (NOT in the TODO backlog) ──
+    // Excluded from the lint re-enable effort on performance grounds: the
+    // "fixed" form is measurably slower than the construct it replaces.
+
+    // Spread over .concat()/.slice() allocates via the iterator protocol —
+    // slower than Array#concat/#slice in hot paths (report.ts, schema-compiler.ts).
+    'unicorn/prefer-spread': 'off',
+
+    // for…of adds iterator-protocol overhead vs indexed access in validation
+    // hot paths (validation/array.ts items loop, report.ts path building).
+    'typescript/prefer-for-of': 'off',
+
     // ── TODO: rules from the ultracite preset currently reporting errors ──
     // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
 
@@ -128,14 +140,6 @@ export default defineConfig({
     // type: best-practice
     // Disallows empty function bodies unless explicitly opted out with a comment explaining the intent.
     'no-empty-function': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 15
-    // complexity: easy
-    // Array spreading (`[...a]`) is preferred over `.concat()` / `Array.from()` by this rule; mechanical substitution.
-    // type: style
-    // Prefers the spread operator over older array-copying methods such as `.concat()` and `Array.from()`.
-    'unicorn/prefer-spread': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 15
@@ -258,28 +262,12 @@ export default defineConfig({
     'promise/avoid-new': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 6
-    // complexity: trivial
-    // `for` loops iterate over arrays/iterables where `for...of` is cleaner; mechanical conversion.
-    // type: style
-    // Prefers `for...of` loops over index-based `for` loops when the index variable is not used.
-    'typescript/prefer-for-of': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 4
     // complexity: dangerous
     // `delete obj[key]` is used with dynamic keys; replacing with explicit property removal or `Map` usage requires careful refactoring.
     // type: bug-prevention
     // Disallows the `delete` operator on computed/dynamic object properties, which can cause performance issues and type unsafety.
     'typescript/no-dynamic-delete': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 4
-    // complexity: trivial
-    // JSDoc `@returns`, `@param`, etc. tags have empty bodies; adding a description or removing the tag is mechanical.
-    // type: style
-    // Disallows JSDoc tags (e.g., `@returns`, `@param`) that are present but have no description content.
-    'jsdoc/empty-tags': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 4
@@ -315,27 +303,11 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 3
-    // complexity: trivial
-    // `type` and `interface` declarations are mixed; the rule requires one consistent form.
-    // type: style
-    // Enforces a consistent use of either `interface` or `type` for TypeScript object type definitions.
-    'typescript/consistent-type-definitions': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
     // complexity: moderate
     // Error-first callbacks are used but the error argument is not checked before proceeding; each site requires an explicit error guard.
     // type: bug-prevention
     // Requires error-first callback parameters to be handled (checked or re-thrown) rather than silently ignored.
     'node/handle-callback-err': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
-    // complexity: trivial
-    // Type-only imports mix inline `type` specifiers and top-level `import type`; normalising to one form is mechanical.
-    // type: style
-    // Enforces consistent positioning of the `type` specifier in type-only imports (`import type` vs `import { type }`).
-    'import/consistent-type-specifier-style': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
@@ -387,14 +359,6 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
-    // complexity: easy
-    // Type assertions are redundant because the value is already of the asserted type; removing them is mechanical after verification.
-    // type: type-safety
-    // Disallows type assertions (`as T`) that are unnecessary because the value is already typed correctly.
-    'typescript/no-unnecessary-type-assertion': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
     // complexity: moderate
     // A `void`-typed expression is used in a non-void context (e.g., passed as a value); restructuring is required to avoid the confusion.
     // type: type-safety
@@ -419,14 +383,6 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
-    // complexity: trivial
-    // Some `import` statements appear after non-import statements in a module; moving them to the top is mechanical.
-    // type: style
-    // Requires all `import` declarations to appear before other statements in a module.
-    'import/first': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
     // complexity: easy
     // `new Promise((resolve, reject) => { ... })` is returned directly from another promise chain; wrapping can be simplified.
     // type: best-practice
@@ -440,14 +396,6 @@ export default defineConfig({
     // type: best-practice
     // Prefers `Set.prototype.has()` over `Array.prototype.includes()` for membership tests on large or frequently-queried collections.
     'unicorn/prefer-set-has': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // `indexOf` is used for a membership check where `Array.prototype.includes()` is clearer.
-    // type: style
-    // Prefers `Array.prototype.includes()` over `indexOf` comparisons for readability.
-    'unicorn/prefer-includes': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
@@ -475,14 +423,6 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
-    // complexity: trivial
-    // A built-in like `Array` or `Object` is called without `new`; using `new` or the literal form is required.
-    // type: bug-prevention
-    // Requires the `new` keyword when constructing built-in objects (e.g., `new Array()` instead of `Array()`).
-    'unicorn/new-for-builtins': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
     // complexity: moderate
     // A custom `Error` subclass does not follow the expected pattern (name property, correct prototype chain); refactoring requires care.
     // type: best-practice
@@ -496,22 +436,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows the `+` operator when its operands have types that could produce an unintended string/number concatenation.
     'typescript/restrict-plus-operands': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // A type assertion can be replaced with a non-null assertion (`!`) which is shorter and conveys the same intent.
-    // type: style
-    // Prefers the non-null assertion operator over `as NonNullable<T>` type assertions when the value is known to be non-null.
-    'typescript/non-nullable-type-assertion-style': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // A template literal contains only a single expression with no surrounding text; a plain expression suffices.
-    // type: style
-    // Disallows template literals that contain only a single expression and no literal text, where a plain expression would do.
-    'typescript/no-unnecessary-template-expression': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
@@ -544,14 +468,6 @@ export default defineConfig({
     // type: bug-prevention
     // Disallows importing a module's default export using a named import specifier.
     'import/no-named-as-default': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: trivial
-    // Multiple variable declarations in a single `var`/`let`/`const` statement are not sorted alphabetically.
-    // type: style
-    // Requires variables declared in the same statement to be sorted alphabetically.
-    'sort-vars': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -119,7 +119,7 @@ const regexValidator: FormatValidatorFn = (input: unknown) => {
   }
 
   try {
-    RegExp(input);
+    new RegExp(input);
     return true;
   } catch {
     return false;

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -2,7 +2,9 @@ import type { JsonSchema, JsonSchemaInternal } from './json-schema-versions.js';
 import type { Reference } from './schema-compiler.js';
 import type { ZSchemaOptions } from './z-schema-options.js';
 
+import { DEFAULT_MAX_RECURSION_DEPTH } from './utils/constants.js';
 import { getRemotePath, isAbsoluteUri } from './utils/uri.js';
+import { isObject } from './utils/what-is.js';
 
 /**
  * Keywords whose values are not JSON Schema sub-schemas and must not be
@@ -12,8 +14,6 @@ export const NON_SCHEMA_KEYWORDS = ['enum', 'const', 'default', 'examples'] as c
 
 /** Returns true if the key is an internal z-schema property (prefixed with `__$`). */
 export const isInternalKey = (key: string): boolean => key.startsWith('__$');
-import { DEFAULT_MAX_RECURSION_DEPTH } from './utils/constants.js';
-import { isObject } from './utils/what-is.js';
 
 /**
  * Properties present in ALL JSON Schema drafts (04 through 2020-12) with

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -1,4 +1,5 @@
 import type { JsonSchemaAll, JsonSchemaInternal } from './json-schema-versions.js';
+import type { JsonValidatorFn } from './validation/shared.js';
 import type { ZSchemaBase } from './z-schema-base.js';
 
 import { getId } from './json-schema.js';
@@ -48,7 +49,6 @@ import { resolveDynamicRef, resolveRecursiveRef } from './validation/ref.js';
 import {
   getCachedValidationResult,
   isValidationVocabularyEnabled,
-  type JsonValidatorFn,
   VALIDATION_VOCAB_KEYWORDS,
 } from './validation/shared.js';
 import {
@@ -65,23 +65,23 @@ import { constValidator, enumValidator, typeValidator } from './validation/type.
 // collectEvaluated — unified traversal for unevaluatedItems / unevaluatedProperties
 // ---------------------------------------------------------------------------
 
-type CollectEvaluatedItemsArgs = {
+interface CollectEvaluatedItemsArgs {
   report: Report;
   currentSchema: JsonSchemaInternal | boolean | undefined;
   json: unknown;
   mode: 'items';
   jsonArr: unknown[];
   depth: number;
-};
+}
 
-type CollectEvaluatedPropertiesArgs = {
+interface CollectEvaluatedPropertiesArgs {
   report: Report;
   currentSchema: JsonSchemaInternal | boolean | undefined;
   json: unknown;
   mode: 'properties';
   jsonData: Record<string, unknown>;
   depth: number;
-};
+}
 
 type CollectEvaluatedArgs = CollectEvaluatedItemsArgs | CollectEvaluatedPropertiesArgs;
 
@@ -116,7 +116,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
         currentSchema: subSchema,
         json,
         mode: 'items',
-        jsonArr: (args as CollectEvaluatedItemsArgs).jsonArr,
+        jsonArr: args.jsonArr,
         depth: depth + 1,
       });
     }
@@ -125,14 +125,14 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
       currentSchema: subSchema,
       json,
       mode: 'properties',
-      jsonData: (args as CollectEvaluatedPropertiesArgs).jsonData,
+      jsonData: args.jsonData,
       depth: depth + 1,
     });
   };
 
   // --- Mode-specific leaf collection ---
   if (mode === 'items') {
-    const jsonArr = (args as CollectEvaluatedItemsArgs).jsonArr;
+    const jsonArr = args.jsonArr;
 
     // prefixItems (2020-12 tuple)
     if (Array.isArray(currentSchema.prefixItems)) {
@@ -184,7 +184,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
     }
   } else {
     // mode === 'properties'
-    const jsonData = (args as CollectEvaluatedPropertiesArgs).jsonData;
+    const jsonData = args.jsonData;
 
     // properties
     if (isObject(currentSchema.properties)) {
@@ -728,7 +728,7 @@ export function validate(
   let pushedRecursiveAnchor = false;
   let pushedDynamicScope = false;
   const schemaId = getId(schema);
-  const schemaResourceRoot = (schema as JsonSchemaInternal).__$resourceRoot;
+  const schemaResourceRoot = schema.__$resourceRoot;
   const dynamicScopeEntry = schemaResourceRoot || (isRoot || typeof schemaId === 'string' ? schema : undefined);
   if (dynamicScopeEntry && dynamicScopeStack.at(-1) !== dynamicScopeEntry) {
     dynamicScopeStack.push(dynamicScopeEntry);

--- a/src/validation/shared.ts
+++ b/src/validation/shared.ts
@@ -84,7 +84,7 @@ export const isValidationVocabularyEnabled = (
     return true;
   }
 
-  const vocabulary = metaSchema.$vocabulary as Record<string, boolean>;
+  const vocabulary = metaSchema.$vocabulary;
   const has2019 = Object.hasOwn(vocabulary, VOCAB_VALIDATION_2019_09);
   const has2020 = Object.hasOwn(vocabulary, VOCAB_VALIDATION_2020_12);
 
@@ -119,7 +119,7 @@ export const isFormatAssertionVocabEnabled = (
     return false; // no vocabulary info, default to annotation-only for modern drafts
   }
 
-  const vocabulary = metaSchema.$vocabulary as Record<string, boolean>;
+  const vocabulary = metaSchema.$vocabulary;
 
   // For draft 2020-12, only the format-assertion vocabulary enables format as assertion
   if (Object.hasOwn(vocabulary, VOCAB_FORMAT_ASSERTION_2020_12)) {

--- a/src/validation/type.ts
+++ b/src/validation/type.ts
@@ -34,8 +34,8 @@ export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSch
   if (shouldSkipValidate(this.validateOptions, ['ENUM_CASE_MISMATCH', 'ENUM_MISMATCH'])) {
     return;
   }
-  let match = false,
-    caseInsensitiveMatch = false;
+  let caseInsensitiveMatch = false,
+    match = false;
   for (const enumVal of schema.enum!) {
     if (areEqual(json, enumVal, { maxDepth: this.options.maxRecursionDepth })) {
       match = true;

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -1,9 +1,10 @@
+import type { Errors, ValidateError } from './errors.js';
 import type { FormatValidatorFn } from './format-validators.js';
 import type { JsonSchema, JsonSchemaInternal, JsonSchemaVersion } from './json-schema-versions.js';
 import type { SchemaErrorDetail } from './report.js';
 import type { ZSchemaOptions } from './z-schema-options.js';
 
-import { type Errors, type ValidateError, getValidateError } from './errors.js';
+import { getValidateError } from './errors.js';
 import { getSupportedFormats } from './format-validators.js';
 import { VERSION_SCHEMA_URL_MAPPING } from './json-schema-versions.js';
 import { isInternalKey } from './json-schema.js';
@@ -25,7 +26,10 @@ export interface ValidateOptions {
   excludeErrors?: Array<keyof typeof Errors>;
 }
 
-export type ValidateResponse = { valid: boolean; err?: ValidateError };
+export interface ValidateResponse {
+  valid: boolean;
+  err?: ValidateError;
+}
 
 export type ValidateCallback = (err: ValidateResponse['err'], valid: ValidateResponse['valid']) => void;
 
@@ -186,13 +190,13 @@ export class ZSchemaBase {
     const report = new Report(this.options);
 
     if (Array.isArray(schemaOrArr)) {
-      const arr = this.scache.getSchema(report, schemaOrArr)!;
+      const arr = this.scache.getSchema(report, schemaOrArr);
       const compiled = this.sc.compileSchema(report, arr);
       if (compiled) {
         this.sv.validateSchema(report, arr);
       }
     } else {
-      const schema = this.scache.getSchema(report, schemaOrArr)!;
+      const schema = this.scache.getSchema(report, schemaOrArr);
       const compiled = this.sc.compileSchema(report, schema);
       if (compiled) {
         this.sv.validateSchema(report, schema);
@@ -334,9 +338,9 @@ export class ZSchemaBase {
       for (key in schema) {
         if (Object.hasOwn(schema, key)) {
           if (isInternalKey(key)) {
-            delete (schema as any)[key];
+            delete schema[key];
           } else {
-            cleanup((schema as any)[key]);
+            cleanup(schema[key]);
           }
         }
       }

--- a/src/z-schema-options.ts
+++ b/src/z-schema-options.ts
@@ -1,7 +1,8 @@
 import type { FormatValidatorFn } from './format-validators.js';
+import type { JsonSchemaVersion } from './json-schema-versions.js';
 import type { Report } from './report.js';
 
-import { CURRENT_DEFAULT_SCHEMA_VERSION, type JsonSchemaVersion } from './json-schema-versions.js';
+import { CURRENT_DEFAULT_SCHEMA_VERSION } from './json-schema-versions.js';
 import { shallowClone } from './utils/clone.js';
 import { DEFAULT_MAX_RECURSION_DEPTH, MAX_ASYNC_TIMEOUT } from './utils/constants.js';
 

--- a/src/z-schema.ts
+++ b/src/z-schema.ts
@@ -15,7 +15,7 @@ import { defaultOptions } from './z-schema-options.js';
 import { getSchemaReader, setSchemaReader } from './z-schema-reader.js';
 
 export class ZSchema extends ZSchemaBase {
-  /** @internal Use ZSchema.create() instead. */
+  /** Use ZSchema.create() instead. @internal */
   constructor(options: ZSchemaOptions | undefined, token: symbol) {
     super(options, token);
   }
@@ -221,7 +221,7 @@ export class ZSchema extends ZSchemaBase {
  * Created via `ZSchema.create({ safe: true })`.
  */
 export class ZSchemaSafe extends ZSchemaBase {
-  /** @internal Use ZSchema.create() instead. */
+  /** Use ZSchema.create() instead. @internal */
   constructor(options: ZSchemaOptions | undefined, token: symbol) {
     super(options, token);
   }
@@ -262,7 +262,7 @@ export class ZSchemaSafe extends ZSchemaBase {
  * Created via `ZSchema.create({ async: true })`.
  */
 export class ZSchemaAsync extends ZSchemaBase {
-  /** @internal Use ZSchema.create() instead. */
+  /** Use ZSchema.create() instead. @internal */
   constructor(options: ZSchemaOptions | undefined, token: symbol) {
     super(options, token);
   }
@@ -301,7 +301,7 @@ export class ZSchemaAsync extends ZSchemaBase {
  * Created via `ZSchema.create({ async: true, safe: true })`.
  */
 export class ZSchemaAsyncSafe extends ZSchemaBase {
-  /** @internal Use ZSchema.create() instead. */
+  /** Use ZSchema.create() instead. @internal */
   constructor(options: ZSchemaOptions | undefined, token: symbol) {
     super(options, token);
   }

--- a/test/ZSchemaTestSuite/Issue126.ts
+++ b/test/ZSchemaTestSuite/Issue126.ts
@@ -32,7 +32,7 @@ export default {
       valid: false,
       after(err: any, valid: any, data: any, validator: any) {
         err.forEach(function (e: any) {
-          if (e.params.indexOf(REF_NAME) !== -1) {
+          if (e.params.includes(REF_NAME)) {
             expect(e.code).not.toBe('UNRESOLVABLE_REFERENCE');
           }
         });

--- a/test/spec/issue-224.spec.ts
+++ b/test/spec/issue-224.spec.ts
@@ -147,6 +147,6 @@ describe('Issue #224: Not getting all schema errors from optional parent object'
     expect(paths).toContain('#/optionalFatherObject/name');
     expect(paths).toContain('#/optionalFatherObject/birthUnixTime');
     const missingProp = details.find((e) => e.code === 'OBJECT_MISSING_REQUIRED_PROPERTY');
-    expect(missingProp!.params![0]).toBe('name2');
+    expect(missingProp!.params[0]).toBe('name2');
   });
 });

--- a/test/spec/json-schema-test-suite.common.ts
+++ b/test/spec/json-schema-test-suite.common.ts
@@ -60,7 +60,7 @@ export async function runTests({ reader }: { reader: <T>(testFilePath: string) =
 
   const versionsTested = Object.keys(VERSION_FOLDER_MAPPING) as JsonSchemaVersion[];
   for (const version of versionsTested) {
-    describe(`${version}`, () => {
+    describe(version, () => {
       const draftPath = `${testsPath}/${VERSION_FOLDER_MAPPING[version]}`;
       const testFiles = manifest.filter((f) => f.startsWith(draftPath));
       testFiles.forEach((testFilePath) => {

--- a/test/spec/keyword-field.spec.ts
+++ b/test/spec/keyword-field.spec.ts
@@ -31,7 +31,7 @@ describe('Error objects include `keyword` field', function () {
     } as any;
 
     try {
-      validator.validateSchema(badSchema as any);
+      validator.validateSchema(badSchema);
       expect.fail('Expected validateSchema to throw');
     } catch (error) {
       expect(error).toBeInstanceOf(ValidateError);

--- a/test/spec/z-schema-test-suite.spec.ts
+++ b/test/spec/z-schema-test-suite.spec.ts
@@ -177,7 +177,7 @@ describe('ZSchemaTestSuite', function () {
           setup(validator, ZSchema);
         }
 
-        let valid;
+        let valid: boolean | undefined;
         try {
           validator.validateSchema(schema as any);
           valid = true;
@@ -214,7 +214,7 @@ describe('ZSchemaTestSuite', function () {
         }
 
         if (after) {
-          after(err?.details ?? err ?? undefined, valid as boolean, data, validator);
+          after(err?.details ?? err ?? undefined, valid!, data, validator);
         }
       }, 1000);
     });


### PR DESCRIPTION
## Summary

Continues the oxlint TODO-backlog reduction effort (#414/#416/#417). Re-enables 10 mechanically auto-fixable rules and promotes two performance-sensitive rules to the intentional-overrides block instead of re-enabling them.

### Re-enabled (all auto-fixable, perf-neutral)
| Rule | Fixes |
| --- | --- |
| `typescript/no-unnecessary-type-assertion` | dropped redundant `as T` / `!` |
| `jsdoc/empty-tags` | moved text out of void `@internal` tags |
| `import/consistent-type-specifier-style` | inline `{ type X }` → top-level `import type` |
| `typescript/consistent-type-definitions` | `type X = {…}` → `interface X {…}` |
| `import/first` | hoisted stray imports to the top |
| `typescript/non-nullable-type-assertion-style` | `as boolean` → `!` |
| `typescript/no-unnecessary-template-expression` | `\` → `version` |
| `unicorn/prefer-includes` | `indexOf(x) !== -1` → `includes(x)` |
| `unicorn/new-for-builtins` | `RegExp(x)` → `new RegExp(x)` |
| `sort-vars` | sorted vars in a single declaration |

### Kept off for performance (promoted to intentional overrides)
- `unicorn/prefer-spread` — spread over `.concat()`/`.slice()` allocates via the iterator protocol; slower than `Array#concat`/`#slice` in hot paths.
- `typescript/prefer-for-of` — `for…of` adds iterator-protocol overhead vs indexed access in validation hot paths.

### Notes
- `test/spec/z-schema-test-suite.spec.ts`: annotated `let valid: boolean | undefined` so oxlint-tsgolint and tsc agree on the type (the `!` assertion is otherwise stripped by one engine and required by the other).

## Verification
- `npm run check` — clean (lint + format)
- `npm run build` + `npm run build:tests` — pass
- `npm test` — 32389 passed (102 files)