### PR TITLE
perf: replace slower constructs with faster equivalents across hot paths

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -7,14 +7,14 @@ Line coverage status: **high**
 | File                          |  Line % | Statement % | Function % | Branch % |
 | ----------------------------- | ------: | ----------: | ---------: | -------: |
 | src/errors.ts                 |    100% |        100% |       100% |     100% |
-| src/format-validators.ts      |     94% |         94% |        93% |      92% |
+| src/format-validators.ts      |     94% |         94% |        90% |      92% |
 | src/json-schema-versions.ts   |    100% |        100% |       100% |     100% |
 | src/json-schema.ts            |     98% |         98% |       100% |      98% |
-| src/json-validation.ts        |     91% |         91% |        97% |      91% |
-| src/report.ts                 |     94% |         95% |        95% |      88% |
+| src/json-validation.ts        |     91% |         91% |       100% |      89% |
+| src/report.ts                 |     94% |         94% |        95% |      88% |
 | src/schema-cache.ts           |     90% |         90% |        92% |      89% |
-| src/schema-compiler.ts        |     94% |         94% |       100% |      90% |
-| src/schema-validator.ts       |     81% |         81% |       100% |      77% |
+| src/schema-compiler.ts        |     93% |         93% |       100% |      90% |
+| src/schema-validator.ts       |     80% |         80% |       100% |      77% |
 | src/utils/array.ts            |    100% |        100% |       100% |     100% |
 | src/utils/base64.ts           |     65% |         65% |       100% |      63% |
 | src/utils/clone.ts            |     97% |         98% |       100% |      94% |
@@ -42,4 +42,4 @@ Line coverage status: **high**
 | src/z-schema-reader.ts        |    100% |        100% |       100% |     100% |
 | src/z-schema-versions.ts      |    100% |        100% |       100% |      75% |
 | src/z-schema.ts               |     76% |         76% |        81% |     100% |
-| **Total**                     | **90%** |     **91%** |    **96%** |  **88%** |
+| **Total**                     | **90%** |     **91%** |    **95%** |  **88%** |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -42,6 +42,12 @@ export default defineConfig({
     // hot paths (validation/array.ts items loop, report.ts path building).
     'typescript/prefer-for-of': 'off',
 
+    // charCodeAt is the correct, faster primitive for ASCII range checks and
+    // manual surrogate-pair scanning (format-validators.ts percent-encoding,
+    // utils/unicode.ts length). codePointAt does extra surrogate work we don't
+    // need on these hot per-character paths.
+    'unicorn/prefer-code-point': 'off',
+
     // ── TODO: rules from the ultracite preset currently reporting errors ──
     // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
 

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -29,12 +29,15 @@ const dateTimeValidator: FormatValidatorFn = (dateTime: unknown) => {
     return true;
   }
   // date-time from http://tools.ietf.org/html/rfc3339#section-5.6
-  const s = dateTime.toLowerCase().split('t');
-  if (s.length !== 2) {
+  let tIdx = dateTime.indexOf('T');
+  if (tIdx === -1) {
+    tIdx = dateTime.indexOf('t');
+  }
+  if (tIdx === -1) {
     return false;
   }
-  const datePart = s[0];
-  const timePart = s[1];
+  const datePart = dateTime.slice(0, tIdx);
+  const timePart = dateTime.slice(tIdx + 1);
   // Check date
   const dateMatches = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/.exec(datePart);
   if (dateMatches === null) {
@@ -96,12 +99,13 @@ const ipv6Validator: FormatValidatorFn = (ipv6: unknown) => {
   return isIPModule.default(ipv6, 6);
 };
 
+const INVALID_REGEX_ESCAPES = new Set(['a']);
+
 const regexValidator: FormatValidatorFn = (input: unknown) => {
   if (typeof input !== 'string') {
     return true;
   }
 
-  const invalidEscapes = new Set(['a']);
   for (let idx = 0; idx < input.length; idx++) {
     if (input[idx] !== '\\') {
       continue;
@@ -113,7 +117,7 @@ const regexValidator: FormatValidatorFn = (input: unknown) => {
     }
 
     const escaped = input[idx];
-    if (invalidEscapes.has(escaped)) {
+    if (INVALID_REGEX_ESCAPES.has(escaped)) {
       return false;
     }
   }
@@ -163,7 +167,7 @@ const durationValidator: FormatValidatorFn = (input: unknown) => {
     return false;
   }
 
-  const hasDateComponent = /\d+[YMD]/.test(datePart);
+  const hasDateComponent = datePart.length > 0;
   let hasTimeComponent = false;
 
   if (timePart !== undefined) {
@@ -193,9 +197,14 @@ const uuidValidator: FormatValidatorFn = (input: unknown) => {
 
 const strictUriValidator: FormatValidatorFn = (uri: unknown) => typeof uri !== 'string' || isURLModule.default(uri);
 
+const isHexChar = (c: number) => (c >= 48 && c <= 57) || (c >= 65 && c <= 70) || (c >= 97 && c <= 102);
+
 const hasValidPercentEncoding = (str: string): boolean => {
   for (let i = 0; i < str.length; i++) {
-    if (str[i] === '%' && (i + 2 >= str.length || !/[0-9a-fA-F]/.test(str[i + 1]) || !/[0-9a-fA-F]/.test(str[i + 2]))) {
+    if (
+      str[i] === '%' &&
+      (i + 2 >= str.length || !isHexChar(str.charCodeAt(i + 1)) || !isHexChar(str.charCodeAt(i + 2)))
+    ) {
       return false;
     }
   }
@@ -307,9 +316,9 @@ const jsonPointerValidator: FormatValidatorFn = (pointer: unknown) => {
   if (!/^(?:\/[^/]*)+$/.test(pointer)) {
     return false;
   }
-  const tokens = pointer.split('/').slice(1); // first element is empty before leading '/'
-  for (const token of tokens) {
-    if (!hasValidTildeEscapes(token)) {
+  const tokens = pointer.split('/');
+  for (let i = 1; i < tokens.length; i++) {
+    if (!hasValidTildeEscapes(tokens[i])) {
       return false;
     }
   }
@@ -336,9 +345,9 @@ const relativeJsonPointerValidator: FormatValidatorFn = (pointer: unknown) => {
   if (!/^(?:\/[^/]*)+$/.test(suffix)) {
     return false;
   }
-  const tokens = suffix.split('/').slice(1);
-  for (const token of tokens) {
-    if (!hasValidTildeEscapes(token)) {
+  const tokens = suffix.split('/');
+  for (let i = 1; i < tokens.length; i++) {
+    if (!hasValidTildeEscapes(tokens[i])) {
       return false;
     }
   }
@@ -427,6 +436,20 @@ export function getFormatValidators(options?: FormatValidatorsOptions): Record<s
     ...customValidators,
     ...options?.customFormats,
   };
+}
+
+export function resolveFormatValidator(name: string, options?: FormatValidatorsOptions): FormatValidatorFn | undefined {
+  const custom = options?.customFormats;
+  if (custom && Object.hasOwn(custom, name)) {
+    return custom[name] as FormatValidatorFn | undefined;
+  }
+  if (Object.hasOwn(customValidators, name)) {
+    return customValidators[name];
+  }
+  if (options?.strictUris && name === 'uri') {
+    return strictUriValidator;
+  }
+  return inbuiltValidators[name];
 }
 
 export function registerFormat(name: string, validatorFunction: FormatValidatorFn) {

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -11,6 +11,7 @@ import { isObject } from './utils/what-is.js';
  * traversed during schema walking (id collection, reference collection, etc.).
  */
 export const NON_SCHEMA_KEYWORDS = ['enum', 'const', 'default', 'examples'] as const;
+export const NON_SCHEMA_KEYWORDS_SET = new Set<string>(NON_SCHEMA_KEYWORDS);
 
 /** Returns true if the key is an internal z-schema property (prefixed with `__$`). */
 export const isInternalKey = (key: string): boolean => key.startsWith('__$');
@@ -167,7 +168,7 @@ export const findId = (
     // intermediate resources - pointer reference across resource boundary".
     for (let i = keys.length - 1; i >= 0; i--) {
       const k = keys[i];
-      if (isInternalKey(k) || NON_SCHEMA_KEYWORDS.includes(k as any)) {
+      if (isInternalKey(k) || NON_SCHEMA_KEYWORDS_SET.has(k)) {
         continue;
       }
       result = findId(schema[k] as JsonSchemaInternal, id, targetBaseUri, nextBaseUri, maxDepth, _depth + 1);

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -188,7 +188,9 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 
     // properties
     if (isObject(currentSchema.properties)) {
-      for (const key of Object.keys(currentSchema.properties)) {
+      const propKeysCE = Object.keys(currentSchema.properties);
+      for (let i = 0; i < propKeysCE.length; i++) {
+        const key = propKeysCE[i];
         if (Object.hasOwn(jsonData, key)) {
           evaluated.add(key);
         }
@@ -200,9 +202,10 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
       for (const pattern of Object.keys(currentSchema.patternProperties)) {
         const result = compileSchemaRegex(pattern);
         if (result.ok) {
-          for (const key of Object.keys(jsonData)) {
-            if (result.value.test(key)) {
-              evaluated.add(key);
+          const jdKeys = Object.keys(jsonData);
+          for (let i = 0; i < jdKeys.length; i++) {
+            if (result.value.test(jdKeys[i])) {
+              evaluated.add(jdKeys[i]);
             }
           }
         }
@@ -211,7 +214,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 
     // additionalProperties - evaluates all non-properties/non-patternProperties keys
     if (currentSchema.additionalProperties !== undefined) {
-      const propKeys = isObject(currentSchema.properties) ? Object.keys(currentSchema.properties) : [];
+      const propKeySet = new Set(isObject(currentSchema.properties) ? Object.keys(currentSchema.properties) : []);
       const patternRegexes: RegExp[] = [];
       if (isObject(currentSchema.patternProperties)) {
         for (const pattern of Object.keys(currentSchema.patternProperties)) {
@@ -221,11 +224,20 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
           }
         }
       }
-      for (const key of Object.keys(jsonData)) {
-        if (propKeys.includes(key)) {
+      const apKeys = Object.keys(jsonData);
+      for (let i = 0; i < apKeys.length; i++) {
+        const key = apKeys[i];
+        if (propKeySet.has(key)) {
           continue;
         }
-        if (patternRegexes.some((re) => re.test(key))) {
+        let matchedPattern = false;
+        for (let pi = 0; pi < patternRegexes.length; pi++) {
+          if (patternRegexes[pi].test(key)) {
+            matchedPattern = true;
+            break;
+          }
+        }
+        if (matchedPattern) {
           continue;
         }
         evaluated.add(key);
@@ -251,8 +263,8 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 
   // allOf
   if (Array.isArray(currentSchema.allOf)) {
-    for (const subSchema of currentSchema.allOf) {
-      if (merge(recurse(subSchema as JsonSchemaInternal | boolean))) {
+    for (let i = 0; i < currentSchema.allOf.length; i++) {
+      if (merge(recurse(currentSchema.allOf[i] as JsonSchemaInternal | boolean))) {
         return 'all';
       }
     }
@@ -260,7 +272,8 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 
   // anyOf - only matching branches contribute
   if (Array.isArray(currentSchema.anyOf)) {
-    for (const subSchema of currentSchema.anyOf) {
+    for (let i = 0; i < currentSchema.anyOf.length; i++) {
+      const subSchema = currentSchema.anyOf[i];
       let passed = getCachedValidationResult(report, subSchema, json);
       if (passed === undefined) {
         const subReport = new Report(report);
@@ -275,7 +288,8 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 
   // oneOf - only matching branches contribute
   if (Array.isArray(currentSchema.oneOf)) {
-    for (const subSchema of currentSchema.oneOf) {
+    for (let i = 0; i < currentSchema.oneOf.length; i++) {
+      const subSchema = currentSchema.oneOf[i];
       let passed = getCachedValidationResult(report, subSchema, json);
       if (passed === undefined) {
         const subReport = new Report(report);
@@ -383,7 +397,8 @@ function unevaluatedItemsValidator(this: ZSchemaBase, report: Report, schema: Js
     report.addError('ARRAY_UNEVALUATED_ITEMS', undefined, undefined, schema, 'unevaluatedItems');
   } else {
     // unevaluatedItems as a schema — validate each unevaluated item against it
-    for (const idx of unevaluatedIndices) {
+    for (let i = 0; i < unevaluatedIndices.length; i++) {
+      const idx = unevaluatedIndices[i];
       const subReport = new Report(report);
       validate.call(this, subReport, unevalSchema as JsonSchemaInternal, json[idx]);
       if (subReport.errors.length > 0) {
@@ -432,7 +447,12 @@ function unevaluatedPropertiesValidator(this: ZSchemaBase, report: Report, schem
     return;
   }
 
-  const unevaluatedKeys = allKeys.filter((key) => !evaluatedProperties.has(key));
+  const unevaluatedKeys: string[] = [];
+  for (let i = 0; i < allKeys.length; i++) {
+    if (!evaluatedProperties.has(allKeys[i])) {
+      unevaluatedKeys.push(allKeys[i]);
+    }
+  }
 
   if (unevaluatedKeys.length === 0) {
     return;
@@ -448,7 +468,8 @@ function unevaluatedPropertiesValidator(this: ZSchemaBase, report: Report, schem
     );
   } else {
     // unevaluatedProperties as a schema — validate each unevaluated key against it
-    for (const key of unevaluatedKeys) {
+    for (let i = 0; i < unevaluatedKeys.length; i++) {
+      const key = unevaluatedKeys[i];
       const subReport = new Report(report);
       validate.call(this, subReport, unevalSchema as JsonSchemaInternal, (json as Record<string, unknown>)[key]);
       if (subReport.errors.length > 0) {
@@ -633,22 +654,33 @@ function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInte
   // m - The property name of the child.
   const keys = Object.keys(json);
 
+  // Precompile patternProperties regexes once before the per-key loop
+  const ppCompiled: Array<{ key: string; re: RegExp }> = [];
+  for (let i = 0; i < pp.length; i++) {
+    const r = compileSchemaRegex(pp[i]);
+    if (r.ok) {
+      ppCompiled.push({ key: pp[i], re: r.value });
+    }
+  }
+
   for (const m of keys) {
     const propertyValue = json[m];
+
+    // Hoist membership check: compute once per key
+    const isProp = p.includes(m);
 
     // s - The set of schemas for the child instance.
     const s = [];
 
     // 1. If set "p" contains value "m", then the corresponding schema in "properties" is added to "s".
-    if (p.includes(m)) {
+    if (isProp) {
       s.push(schema.properties![m]);
     }
 
     // 2. For each regex in "pp", if it matches "m" successfully, the corresponding schema in "patternProperties" is added to "s".
-    for (const regexString of pp) {
-      const result = compileSchemaRegex(regexString);
-      if (result.ok && result.value.test(m)) {
-        s.push(schema.patternProperties![regexString]);
+    for (let i = 0; i < ppCompiled.length; i++) {
+      if (ppCompiled[i].re.test(m)) {
+        s.push(schema.patternProperties![ppCompiled[i].key]);
       }
     }
 
@@ -665,7 +697,7 @@ function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInte
     for (const schema_s of s) {
       report.path.push(m);
       // Track schema path for properties validation
-      if (p.includes(m)) {
+      if (isProp) {
         // This is a defined property
         report.schemaPath.push('properties');
         report.schemaPath.push(m);
@@ -676,7 +708,7 @@ function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInte
       validate.call(this, report, schema_s, propertyValue);
       report.path.pop();
       report.schemaPath.pop();
-      if (p.includes(m)) {
+      if (isProp) {
         report.schemaPath.pop(); // pop the property name for defined properties
       }
     }
@@ -750,7 +782,10 @@ export function validate(
       } else {
         validate.call(this, report, schema.__$refResolved as JsonSchemaInternal, json);
       }
-      keys = keys.filter((key) => key !== '$ref');
+      const refIdx = keys.indexOf('$ref');
+      if (refIdx !== -1) {
+        keys.splice(refIdx, 1);
+      }
     } else {
       // avoid infinite loop with maxRefs
       let maxRefs = 99;
@@ -787,7 +822,10 @@ export function validate(
       } else {
         validate.call(this, report, recursiveRefTarget, json);
       }
-      keys = keys.filter((key) => key !== '$recursiveRef');
+      const recursiveRefIdx = keys.indexOf('$recursiveRef');
+      if (recursiveRefIdx !== -1) {
+        keys.splice(recursiveRefIdx, 1);
+      }
     }
   }
 
@@ -803,13 +841,22 @@ export function validate(
       } else {
         validate.call(this, report, dynamicRefTarget, json);
       }
-      keys = keys.filter((key) => key !== '$dynamicRef');
+      const dynamicRefIdx = keys.indexOf('$dynamicRef');
+      if (dynamicRefIdx !== -1) {
+        keys.splice(dynamicRefIdx, 1);
+      }
     }
   }
 
   const validationVocabularyEnabled = isValidationVocabularyEnabled(schema, report, this.options.version);
   if (!validationVocabularyEnabled) {
-    keys = keys.filter((key) => !VALIDATION_VOCAB_KEYWORDS.has(key));
+    let wi = 0;
+    for (let ri = 0; ri < keys.length; ri++) {
+      if (!VALIDATION_VOCAB_KEYWORDS.has(keys[ri])) {
+        keys[wi++] = keys[ri];
+      }
+    }
+    keys.length = wi;
   }
 
   // type checking first
@@ -833,7 +880,8 @@ export function validate(
   // Defer unevaluatedItems/unevaluatedProperties to run after other validators,
   // so combinator validation results are cached and available for annotation collection
   const deferredUnevaluatedKeys: Array<keyof JsonSchemaAll> = [];
-  for (const key of keys) {
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
     if (key === 'unevaluatedItems' || key === 'unevaluatedProperties') {
       deferredUnevaluatedKeys.push(key);
       continue;
@@ -849,7 +897,8 @@ export function validate(
 
   // Run unevaluated* validators after all others have cached their combinator results
   if (deferredUnevaluatedKeys.length > 0 && !(report.errors.length > 0 && this.options.breakOnFirstError)) {
-    for (const key of deferredUnevaluatedKeys) {
+    for (let i = 0; i < deferredUnevaluatedKeys.length; i++) {
+      const key = deferredUnevaluatedKeys[i];
       const validator = JsonValidators[key];
       if (validator) {
         validator.call(this, report, schema, json);

--- a/src/report.ts
+++ b/src/report.ts
@@ -102,8 +102,8 @@ export class Report {
       // subreport
       this.reportOptions = (reportOptionsOrValidate as ReportOptions) || {};
       this.validateOptions = validateOptions || parentOrOptions.validateOptions;
-      this.__$recursiveAnchorStack = [...parentOrOptions.__$recursiveAnchorStack];
-      this.__$dynamicScopeStack = [...parentOrOptions.__$dynamicScopeStack];
+      this.__$recursiveAnchorStack = parentOrOptions.__$recursiveAnchorStack.slice();
+      this.__$dynamicScopeStack = parentOrOptions.__$dynamicScopeStack.slice();
       this.__validationResultCache = parentOrOptions.__validationResultCache;
     } else {
       // primary
@@ -212,11 +212,9 @@ export class Report {
   }
 
   getPath(returnPathAsString?: boolean) {
-    let path: Array<string | number> = [];
-    if (this.parentReport) {
-      path = path.concat(this.parentReport.path);
-    }
-    path = path.concat(this.path);
+    const path: Array<string | number> = this.parentReport
+      ? this.parentReport.path.concat(this.path)
+      : this.path.slice();
 
     if (returnPathAsString !== true) {
       // Sanitize the path segments (http://tools.ietf.org/html/rfc6901#section-4)
@@ -236,12 +234,10 @@ export class Report {
   }
 
   getSchemaPath(): Array<string | number> {
-    let schemaPath: Array<string | number> = [];
     if (this.parentReport) {
-      schemaPath = schemaPath.concat(this.parentReport.schemaPath);
+      return this.parentReport.schemaPath.concat(this.schemaPath);
     }
-    schemaPath = schemaPath.concat(this.schemaPath);
-    return schemaPath;
+    return this.schemaPath.slice();
   }
 
   getSchemaId(): string | undefined {
@@ -250,11 +246,7 @@ export class Report {
     }
 
     // get the error path as an array
-    let path: Array<string | number> = [];
-    if (this.parentReport) {
-      path = path.concat(this.parentReport.path);
-    }
-    path = path.concat(this.path);
+    const path = this.parentReport ? this.parentReport.path.concat(this.path) : this.path.slice();
 
     // try to find id in the error path
     while (path.length > 0) {
@@ -367,9 +359,10 @@ export class Report {
         subReports = [subReports];
       }
       err.inner = [];
-      for (const subReport of subReports) {
-        for (const error of subReport.errors) {
-          err.inner.push(error);
+      for (let si = 0; si < subReports.length; si++) {
+        const errs = subReports[si].errors;
+        for (let ei = 0; ei < errs.length; ei++) {
+          err.inner.push(errs[ei]);
         }
       }
       if (err.inner.length === 0) {

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -1,7 +1,7 @@
 import type { JsonSchemaInternal } from './json-schema-versions.js';
 import type { ZSchemaBase } from './z-schema-base.js';
 
-import { getId, isInternalKey, NON_SCHEMA_KEYWORDS } from './json-schema.js';
+import { getId, isInternalKey, NON_SCHEMA_KEYWORDS_SET } from './json-schema.js';
 import { Report } from './report.js';
 import { DEFAULT_MAX_RECURSION_DEPTH } from './utils/constants.js';
 import { getRemotePath, isAbsoluteUri } from './utils/uri.js';
@@ -79,9 +79,15 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
       } else if (type === 'root' && typeof node.id === 'string' && isAbsoluteUri(node.id) && node.id !== nodeId) {
         id.absoluteUri = resolveSchemaScopeId(node.id, node as JsonSchemaInternal, nodeId);
       } else if (type === 'relative') {
-        id.absoluteParent = scope
-          .filter((x) => x.type === 'absolute' || (x.type === 'root' && x.absoluteUri))
-          .slice(-1)[0];
+        let absoluteParent: Id | undefined;
+        for (let i = scope.length - 1; i >= 0; i--) {
+          const sc = scope[i];
+          if (sc.type === 'absolute' || (sc.type === 'root' && sc.absoluteUri)) {
+            absoluteParent = sc;
+            break;
+          }
+        }
+        id.absoluteParent = absoluteParent;
         if (id.absoluteParent) {
           const parentUri = id.absoluteParent.absoluteUri || id.absoluteParent.id;
           id.absoluteUri = resolveSchemaScopeId(parentUri, node as JsonSchemaInternal, id.id);
@@ -98,7 +104,7 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
       }
     } else {
       for (const key of Object.keys(node)) {
-        if (isInternalKey(key) || NON_SCHEMA_KEYWORDS.includes(key as any)) {
+        if (isInternalKey(key) || NON_SCHEMA_KEYWORDS_SET.has(key)) {
           continue;
         }
         walk(node[key], scope, _depth + 1);
@@ -203,7 +209,7 @@ export const collectReferences = (
     const keys = Object.keys(obj);
     for (const key of keys) {
       // do not recurse through resolved references and other z-schema props
-      if (isInternalKey(key) || NON_SCHEMA_KEYWORDS.includes(key as any)) {
+      if (isInternalKey(key) || NON_SCHEMA_KEYWORDS_SET.has(key)) {
         continue;
       }
       path.push(key);
@@ -317,7 +323,9 @@ export class SchemaCompiler {
     // if schema is an array, assume it's an array of schemas
     if (Array.isArray(schema)) {
       if (!options?.noCache) {
-        schema.forEach((s) => this.collectAndCacheIds(s));
+        for (let i = 0; i < schema.length; i++) {
+          this.collectAndCacheIds(schema[i]);
+        }
       }
       return this.compileArrayOfSchemas(report, schema);
     } else if (typeof schema === 'boolean') {
@@ -400,7 +408,9 @@ export class SchemaCompiler {
             const subreport = new Report(report);
             if (!this.compileSchema(subreport, s)) {
               // copy errors to report
-              report.errors = report.errors.concat(subreport.errors);
+              for (let i = 0; i < subreport.errors.length; i++) {
+                report.errors.push(subreport.errors[i]);
+              }
             } else {
               response = this.validator.scache.getSchemaByUri(report, refObj.ref, schema);
             }
@@ -427,9 +437,12 @@ export class SchemaCompiler {
         } else if (isDownloaded) {
           // remote is downloaded, so no UNRESOLVABLE_REFERENCE
         } else {
-          report.path.push(...refObj.path);
+          const pathLen = refObj.path.length;
+          for (let i = 0; i < pathLen; i++) {
+            report.path.push(refObj.path[i]);
+          }
           report.addError('UNRESOLVABLE_REFERENCE', [refObj.ref]);
-          report.path = report.path.slice(0, -refObj.path.length);
+          report.path.length -= pathLen;
 
           // publish unresolved references out
           if (
@@ -472,7 +485,13 @@ export class SchemaCompiler {
 
     do {
       // remove all UNRESOLVABLE_REFERENCE errors before compiling array again
-      report.errors = report.errors.filter((e) => e.code !== 'UNRESOLVABLE_REFERENCE');
+      let wi = 0;
+      for (let ri = 0; ri < report.errors.length; ri++) {
+        if (report.errors[ri].code !== 'UNRESOLVABLE_REFERENCE') {
+          report.errors[wi++] = report.errors[ri];
+        }
+      }
+      report.errors.length = wi;
 
       // remember how many were compiled in the last loop
       lastLoopCompiled = compiled;
@@ -481,11 +500,17 @@ export class SchemaCompiler {
       compiled = this.compileArrayOfSchemasLoop(report, arr);
 
       // fix __$missingReferences if possible
+      const idMap = new Map<string, JsonSchemaInternal>();
+      for (let i = 0; i < arr.length; i++) {
+        if (arr[i].id) {
+          idMap.set(arr[i].id!, arr[i]);
+        }
+      }
       for (const sch of arr) {
         if (sch.__$missingReferences) {
           for (let idx2 = sch.__$missingReferences.length - 1; idx2 >= 0; idx2--) {
             const refObj = sch.__$missingReferences[idx2];
-            const response = arr.find((x) => x.id === refObj.ref);
+            const response = idMap.get(refObj.ref);
             if (response) {
               // this might create circular references
               safeSetProperty(refObj.obj as unknown as Record<string, unknown>, `__${refObj.key}Resolved`, response);
@@ -517,7 +542,9 @@ export class SchemaCompiler {
       }
 
       // copy errors to report
-      mainReport.errors = mainReport.errors.concat(report.errors);
+      for (let i = 0; i < report.errors.length; i++) {
+        mainReport.errors.push(report.errors[i]);
+      }
     }
 
     return compiledCount;

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -500,10 +500,13 @@ export class SchemaCompiler {
       compiled = this.compileArrayOfSchemasLoop(report, arr);
 
       // fix __$missingReferences if possible
+      // Keep the FIRST schema per id to match the prior `arr.find(x => x.id === ref)`
+      // semantics (first match wins) when an array contains duplicate ids.
       const idMap = new Map<string, JsonSchemaInternal>();
       for (let i = 0; i < arr.length; i++) {
-        if (arr[i].id) {
-          idMap.set(arr[i].id!, arr[i]);
+        const schemaId = arr[i].id;
+        if (schemaId && !idMap.has(schemaId)) {
+          idMap.set(schemaId, arr[i]);
         }
       }
       for (const sch of arr) {

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -10,6 +10,10 @@ import { shallowClone } from './utils/clone.js';
 import { compileSchemaRegex } from './utils/schema-regex.js';
 import { isInteger, isObject } from './utils/what-is.js';
 
+const PRIMITIVE_TYPES = ['array', 'boolean', 'integer', 'number', 'null', 'object', 'string'] as const;
+const PRIMITIVE_TYPE_STR = PRIMITIVE_TYPES.join(',');
+const PRIMITIVE_TYPES_SET = new Set<string>(PRIMITIVE_TYPES);
+
 const SchemaValidators = {
   $ref(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
@@ -389,22 +393,20 @@ const SchemaValidators = {
   },
   type(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
     // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.2.1
-    const primitiveTypes = ['array', 'boolean', 'integer', 'number', 'null', 'object', 'string'];
-    const primitiveTypeStr = primitiveTypes.join(',');
     const isArray = Array.isArray(schema.type);
 
     if (Array.isArray(schema.type)) {
       for (const typeItem of schema.type) {
-        if (!primitiveTypes.includes(typeItem)) {
-          report.addError('KEYWORD_TYPE_EXPECTED', ['type', primitiveTypeStr], undefined, schema, 'type');
+        if (!PRIMITIVE_TYPES_SET.has(typeItem)) {
+          report.addError('KEYWORD_TYPE_EXPECTED', ['type', PRIMITIVE_TYPE_STR], undefined, schema, 'type');
         }
       }
       if (!isUniqueArray(schema.type)) {
         report.addError('KEYWORD_MUST_BE', ['type', 'an object with unique properties'], undefined, schema, 'type');
       }
     } else if (typeof schema.type === 'string') {
-      if (!primitiveTypes.includes(schema.type)) {
-        report.addError('KEYWORD_TYPE_EXPECTED', ['type', primitiveTypeStr], undefined, schema, 'type');
+      if (!PRIMITIVE_TYPES_SET.has(schema.type)) {
+        report.addError('KEYWORD_TYPE_EXPECTED', ['type', PRIMITIVE_TYPE_STR], undefined, schema, 'type');
       }
     } else {
       report.addError('KEYWORD_TYPE_EXPECTED', ['type', ['string', 'array']], undefined, schema, 'type');
@@ -738,21 +740,26 @@ export class SchemaValidator {
     if (this.validator.options.noTypeless === true) {
       // issue #36 - inherit type to anyOf, oneOf, allOf if noTypeless is defined
       if (schema.type !== undefined) {
-        let schemas: JsonSchema[] = [];
-        if (Array.isArray(schema.anyOf)) {
-          schemas = schemas.concat(schema.anyOf);
-        }
-        if (Array.isArray(schema.oneOf)) {
-          schemas = schemas.concat(schema.oneOf);
-        }
-        if (Array.isArray(schema.allOf)) {
-          schemas = schemas.concat(schema.allOf);
-        }
-        schemas.forEach(function (sch) {
+        const inheritType = (sch: JsonSchema) => {
           if (!sch.type) {
             sch.type = schema.type;
           }
-        });
+        };
+        if (Array.isArray(schema.anyOf)) {
+          for (let i = 0; i < schema.anyOf.length; i++) {
+            inheritType(schema.anyOf[i]);
+          }
+        }
+        if (Array.isArray(schema.oneOf)) {
+          for (let i = 0; i < schema.oneOf.length; i++) {
+            inheritType(schema.oneOf[i]);
+          }
+        }
+        if (Array.isArray(schema.allOf)) {
+          for (let i = 0; i < schema.allOf.length; i++) {
+            inheritType(schema.allOf[i]);
+          }
+        }
       }
       // end issue #36
       if (

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -49,9 +49,10 @@ export const isUniqueArray = <T>(arr: T[], indexes?: number[], maxDepth?: number
   }
 
   // Slow path: at least one element is an object/array — need deep comparison.
+  const eqOpts = { maxDepth };
   for (let i = 0; i < l; i++) {
     for (let j = i + 1; j < l; j++) {
-      if (areEqual(arr[i], arr[j], { maxDepth })) {
+      if (areEqual(arr[i], arr[j], eqOpts)) {
         if (indexes) {
           indexes.push(i, j);
         }

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -14,8 +14,8 @@ export const shallowClone = <T>(src: T): T => {
   } else {
     res = {};
     const keys = Object.keys(src).sort() as Array<keyof T>;
-    for (const key of keys) {
-      copyProp(src, res, key);
+    for (let i = 0; i < keys.length; i++) {
+      copyProp(src, res, keys[i]);
     }
   }
   return res;
@@ -55,8 +55,8 @@ export const deepClone = <T>(src: T, maxDepth = DEFAULT_MAX_RECURSION_DEPTH): T 
       res = {};
       cloned.push(res);
       const keys = Object.keys(src).sort() as Array<keyof T>;
-      for (const key of keys) {
-        copyProp(src, res, key, (v: any) => cloneDeepInner(v, _depth + 1));
+      for (let i = 0; i < keys.length; i++) {
+        copyProp(src, res, keys[i], (v: any) => cloneDeepInner(v, _depth + 1));
       }
     }
     return res;

--- a/src/utils/hostname.ts
+++ b/src/utils/hostname.ts
@@ -12,8 +12,11 @@ const splitHostnameLabels = (hostname: string): string[] | null => {
     return null;
   }
   const labels = hostname.split('.');
-  if (labels.some((label) => label.length === 0 || label.length > 63)) {
-    return null;
+  for (let i = 0; i < labels.length; i++) {
+    const len = labels[i].length;
+    if (len === 0 || len > 63) {
+      return null;
+    }
   }
   return labels;
 };
@@ -137,7 +140,8 @@ export const isValidHostname = (hostname: string): boolean => {
     return false;
   }
 
-  for (const label of labels) {
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i];
     if (!isAsciiHostnameLabel(label)) {
       return false;
     }
@@ -161,7 +165,8 @@ export const isValidIdnHostname = (hostname: string): boolean => {
     return false;
   }
 
-  for (const label of labels) {
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i];
     const unicodeLabel = toUnicodeLabel(label);
     if (unicodeLabel === null || !isValidIdnUnicodeLabel(unicodeLabel)) {
       return false;

--- a/src/utils/unicode.ts
+++ b/src/utils/unicode.ts
@@ -1,12 +1,19 @@
 /**
  * Returns the number of Unicode code points in the string.
- * Uses the built-in string iterator which correctly handles surrogate pairs.
+ * Uses a surrogate-aware charCodeAt scan (equivalent to the string iterator)
+ * that counts a surrogate pair as one code point and lone surrogates as one each.
  */
 export function unicodeLength(str: string): number {
-  let count = 0;
-  for (const _cp of str) {
-    void _cp;
-    count++;
+  let count = str.length;
+  for (let i = 0; i < str.length - 1; i++) {
+    const hi = str.charCodeAt(i);
+    if (hi >= 0xd8_00 && hi <= 0xdb_ff) {
+      const lo = str.charCodeAt(i + 1);
+      if (lo >= 0xdc_00 && lo <= 0xdf_ff) {
+        count--;
+        i++;
+      }
+    }
   }
   return count;
 }

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -124,8 +124,8 @@ export function containsValidator(this: ZSchemaBase, report: Report, schema: Jso
 
   const addContainsErrorIfNeeded = () => {
     let matchingItems = 0;
-    for (const subReport of subReports) {
-      if (subReport.errors.length === 0) {
+    for (let i = 0; i < subReports.length; i++) {
+      if (subReports[i].errors.length === 0) {
         matchingItems += 1;
       }
     }

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -132,7 +132,8 @@ export function propertiesValidator(this: ZSchemaBase, report: Report, schema: J
     // remove from "s" all elements of "p", if any;
     s = difference(s, p);
     // for each regex in "pp", remove all elements of "s" which this regex matches.
-    for (const ppKey of pp) {
+    for (let i = 0; i < pp.length; i++) {
+      const ppKey = pp[i];
       const result = compileSchemaRegex(ppKey);
       if (!result.ok) {
         continue;

--- a/src/validation/shared.ts
+++ b/src/validation/shared.ts
@@ -165,8 +165,11 @@ export function getCachedValidationResult(report: Report, schema: unknown, json:
  */
 export function deferOrRunSync(report: Report, subReports: Report[], decisionFn: () => void): void {
   const asyncTasksBefore = report.asyncTasks.length;
-  for (const subReport of subReports) {
-    report.asyncTasks.push(...subReport.asyncTasks);
+  for (let i = 0; i < subReports.length; i++) {
+    const tasks = subReports[i].asyncTasks;
+    for (let j = 0; j < tasks.length; j++) {
+      report.asyncTasks.push(tasks[j]);
+    }
   }
   const hasAsyncTasks = report.asyncTasks.length > asyncTasksBefore;
 

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -2,7 +2,7 @@ import type { JsonSchemaInternal } from '../json-schema-versions.js';
 import type { Report } from '../report.js';
 import type { ZSchemaBase } from '../z-schema-base.js';
 
-import { getFormatValidators } from '../format-validators.js';
+import { resolveFormatValidator } from '../format-validators.js';
 import { decodeBase64, isValidBase64 } from '../utils/base64.js';
 import { compileSchemaRegex } from '../utils/schema-regex.js';
 import { unicodeLength } from '../utils/unicode.js';
@@ -85,8 +85,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
 
   const isModernDraft = this.options.version === 'draft2019-09' || this.options.version === 'draft2020-12';
 
-  const formatValidators = getFormatValidators(this.options);
-  const formatValidatorFn = formatValidators[schema.format!];
+  const formatValidatorFn = resolveFormatValidator(schema.format!, this.options);
   if (typeof formatValidatorFn === 'function') {
     if (shouldSkipValidate(this.validateOptions, ['INVALID_FORMAT'])) {
       return;

--- a/src/validation/type.ts
+++ b/src/validation/type.ts
@@ -34,13 +34,15 @@ export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSch
   if (shouldSkipValidate(this.validateOptions, ['ENUM_CASE_MISMATCH', 'ENUM_MISMATCH'])) {
     return;
   }
+  const eqOpts = { maxDepth: this.options.maxRecursionDepth };
+  const eqOptsCI = { caseInsensitiveComparison: true, maxDepth: this.options.maxRecursionDepth };
   let caseInsensitiveMatch = false,
     match = false;
   for (const enumVal of schema.enum!) {
-    if (areEqual(json, enumVal, { maxDepth: this.options.maxRecursionDepth })) {
+    if (areEqual(json, enumVal, eqOpts)) {
       match = true;
       break;
-    } else if (areEqual(json, enumVal, { caseInsensitiveComparison: true, maxDepth: this.options.maxRecursionDepth })) {
+    } else if (areEqual(json, enumVal, eqOptsCI)) {
       caseInsensitiveMatch = true;
     }
   }

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -286,9 +286,11 @@ export class ZSchemaBase {
   getMissingRemoteReferences(err: ValidateError) {
     const missingReferences = this.getMissingReferences(err);
     const missingRemoteReferences: string[] = [];
+    const seen = new Set<string>();
     for (const ref of missingReferences) {
       const remoteReference = getRemotePath(ref);
-      if (remoteReference && !missingRemoteReferences.includes(remoteReference)) {
+      if (remoteReference && !seen.has(remoteReference)) {
+        seen.add(remoteReference);
         missingRemoteReferences.push(remoteReference);
       }
     }


### PR DESCRIPTION
## Summary

A whole-`src/` performance pass replacing slower constructs with faster, behavior-preserving equivalents, per the perf-critical doctrine now documented in `AGENTS.md`. Prioritises genuinely hot paths (per-validation / per-error / per-value) over compile-time paths.

These are pre-existing patterns — the recent lint commits did not introduce regressions; this PR proactively optimises the hot code.

## Highlights (hot paths)

- **report.ts** — `[...stack]` → `.slice()` in the sub-report constructor; `getPath`/`getSchemaPath`/`getSchemaId` collapse a 3-allocation `[]`+double-`concat` into one; indexed loops building `err.inner`.
- **json-validation.ts** — `recurseObject` hoists `p.includes(m)` (was called 3×/property) and **pre-compiles `patternProperties` regexes once per object** instead of per data-key; `collectEvaluated` uses `Set.has()` + indexed loops; `validate` filters `$ref`/vocab keys in place.
- **validators** — drop spread-into-`push` in `deferOrRunSync`; hoist `areEqual` option objects out of enum/uniqueItems loops; indexed loops in `contains`/`properties`.
- **utils** — indexed key loops in `clone`; surrogate-aware `charCodeAt` scan in `unicodeLength`; indexed label loops in `hostname`.
- **format-validators.ts** — hoist the per-call `new Set(['a'])`; add `resolveFormatValidator` so a format check no longer builds a ~20-key merged object per value (preserving precedence); allocation-light `date-time` / `json-pointer` / `duration` / percent-encoding paths.

## Cold (compile-time) paths
`NON_SCHEMA_KEYWORDS_SET`, in-place error/path mutation, an `id→schema` `Map` instead of repeated `arr.find`, and a module-scope primitive-types `Set` in `schema-compiler.ts` / `schema-validator.ts`.

## Lint
`charCodeAt` tripped `unicorn/prefer-code-point`; since `charCodeAt` is the correct/faster primitive for these ASCII/surrogate scans, the rule is disabled in the "Intentionally kept off for performance" block of `oxlint.config.ts` (per project policy: the rule yields to performance, the code does not). All other findings (`curly`, redundant assertions) were complied with.

## Excluded (verified non-issues)
Regex literals inside functions (V8 caches them per source position), fixed tiny-array `includes` (e.g. the ≤7 `type` array), and `includeErrors`/`excludeErrors` Set plumbing (guarded/short-circuited in the common case).

## Verification
- `npm run check` — clean (lint + format)
- `npm run build` + `npm run build:tests` — pass
- `npm test` — **32389 passed** (102 files, node + browser) — the behavior-preservation gate
- No public API change (`getFormatValidators` still exported and identical)
