### PR TITLE
docs: document the full set of performance principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,12 +94,20 @@ All public methods and classes **must** have [TSDoc](https://tsdoc.org/) comment
 Concrete rules:
 
 - **Never replace a faster construct with a slower one for style reasons.** In particular:
-  - Prefer `Array.prototype.concat` / `Array.prototype.slice` over the spread operator (`[...a, ...b]`, `[...a]`). Spread allocates via the iterator protocol and is measurably slower in V8 hot paths.
-  - Prefer index-based `for` loops over `for…of` in validation hot paths. `for…of` adds iterator-protocol overhead versus direct indexed access.
-  - Prefer `Set`/`Map` lookups (`O(1)`) over repeated `Array.prototype.includes`/`indexOf` (`O(n)`) on frequently-queried collections.
-- Avoid unnecessary allocations (intermediate arrays/objects, closures) inside per-keyword and per-element validation loops.
-- Some lint rules that would push code toward the slower form are **intentionally kept `off`** in [oxlint.config.ts](oxlint.config.ts) under the "Intentionally kept off for performance" block (e.g. `unicorn/prefer-spread`, `typescript/prefer-for-of`). Do not re-enable them, and do not silence the resulting wins by hand-applying their fixes.
+  - Prefer `Array.prototype.concat` / `Array.prototype.slice` over the spread operator (`[...a, ...b]`, `[...a]`, `fn(...arr)`, `arr.push(...other)`). Spread allocates via the iterator protocol and is measurably slower in V8 hot paths (and `push(...big)` can overflow the call stack).
+  - Prefer index-based `for` loops over `for…of` and `Array.prototype.forEach` in validation hot paths. `for…of`/`forEach` add iterator-protocol / callback overhead versus direct indexed access.
+  - Prefer `Set`/`Map` lookups (`O(1)`) over repeated `Array.prototype.includes`/`indexOf` (`O(n)`) and over `Array.prototype.find` in loops, on frequently-queried collections.
+  - Prefer `charCodeAt` over `codePointAt` for ASCII range checks and manual surrogate-pair scanning. `codePointAt` does extra surrogate work that is unnecessary on per-character hot paths.
+- **Avoid per-call and per-iteration allocations** inside per-keyword / per-element / per-value paths:
+  - Hoist constant `Set`s/arrays/option-object literals and **regex compilation** to module scope (or above the loop) so they are built once, not on every call or iteration.
+  - Prefer **in-place array mutation** (push in a loop, `arr.length =` truncation, write-index compaction) over `.concat()` / `.filter()` / `.slice()` that allocate a fresh array on hot paths — but only when the array is a private local and no caller relies on a fresh reference.
+  - Don't build a large merged/lookup object per call just to read one key — resolve the single value directly.
+  - Avoid closures allocated per element (e.g. `.some()` / `.filter()` / `.reduce()` callbacks) in hot loops; use an indexed loop with a flag/accumulator.
+- **Lint rules that would push code toward the slower form are intentionally kept `off`** in [oxlint.config.ts](oxlint.config.ts) under the "Intentionally kept off for performance" block (currently `unicorn/prefer-spread`, `typescript/prefer-for-of`, `unicorn/prefer-code-point`). Do not re-enable them, and do not silence the resulting wins by hand-applying their fixes. **If a performance change trips a different enabled rule, the rule yields to performance** — move it into that block (with a one-line rationale comment, following the existing pattern) rather than reverting the faster code. Pure-style rules with no runtime cost (e.g. `curly`) should simply be satisfied.
+- **Behavior preservation is mandatory.** A faster path must produce identical results — same values, order, short-circuit/early-exit semantics, and error paths — for all inputs (including edge cases such as lone surrogates, duplicate ids, empty collections). The full test suite is the gate.
 - If a change might affect performance, benchmark it and call out the result in the PR. When in doubt, favor the faster construct.
+
+See [docs/conventions.md](docs/conventions.md#performance) for worked before/after examples.
 
 ## Testing Guide
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -53,3 +53,50 @@
 
 - Pure utility functions go in `src/utils/`. Each file is single-purpose.
 - Current utils: `array.ts`, `clone.ts`, `json.ts`, `properties.ts`, `schema-regex.ts`, `symbols.ts`, `unicode.ts`, `uri.ts`, `what-is.ts`.
+
+## Performance
+
+Performance is a **primary, non-negotiable goal** — z-schema validates JSON on hot paths that run millions of times. Never trade a faster construct for stylistic sugar. See the Performance section in [AGENTS.md](../AGENTS.md#performance) for the authoritative rule list; the patterns below show the canonical before/after forms.
+
+**Prefer faster array/string primitives:**
+
+```ts
+// ✗ spread (iterator protocol)            ✓ concat / slice
+const a = [...x, ...y];                     const a = x.concat(y);
+const b = [...x];                           const b = x.slice();
+report.path.push(...segs);                  for (let i = 0; i < segs.length; i++) report.path.push(segs[i]);
+
+// ✗ for…of / forEach on hot arrays         ✓ indexed for
+for (const k of keys) use(k);               for (let i = 0; i < keys.length; i++) use(keys[i]);
+
+// ✗ O(n) membership in a loop              ✓ O(1) Set
+if (propKeys.includes(key)) …               const propKeySet = new Set(propKeys); … if (propKeySet.has(key)) …
+
+// ✗ codePointAt for ASCII/surrogate scan   ✓ charCodeAt
+str.codePointAt(i)                          str.charCodeAt(i)
+```
+
+**Avoid per-call / per-iteration allocations** — hoist constants, option objects, and regex compilation; mutate in place; resolve single values directly:
+
+```ts
+// ✗ option literal allocated per iteration
+for (const v of enumVals) if (areEqual(json, v, { maxDepth })) …
+// ✓ hoisted once
+const eqOpts = { maxDepth };
+for (let i = 0; i < enumVals.length; i++) if (areEqual(json, enumVals[i], eqOpts)) …
+
+// ✗ regex compiled per data key            ✓ compiled once before the loop
+for (const key of keys) { const re = compileSchemaRegex(p); … }
+const compiled = patterns.map(compileSchemaRegex); for (…) { /* reuse compiled */ }
+
+// ✗ allocating filter/concat on a hot path ✓ in-place (private local arrays only)
+keys = keys.filter((k) => k !== '$ref');    const i = keys.indexOf('$ref'); if (i !== -1) keys.splice(i, 1);
+report.errors = report.errors.concat(sub);  for (let i = 0; i < sub.length; i++) report.errors.push(sub[i]);
+
+// ✗ build a big merged object to read one key   ✓ resolve the single value directly
+const all = getFormatValidators(opts); all[name];   resolveFormatValidator(name, opts);
+```
+
+**Lint interaction:** rules that would push code back to the slower form are kept `off` in [oxlint.config.ts](../oxlint.config.ts) under the "Intentionally kept off for performance" block (`unicorn/prefer-spread`, `typescript/prefer-for-of`, `unicorn/prefer-code-point`). Do not re-enable them; if a perf change trips another enabled rule, disable that rule there rather than reverting the faster code.
+
+**Behavior preservation is mandatory:** a faster path must be identical for all inputs (lone surrogates, duplicate ids, empty collections, etc.). The full test suite is the gate; in-place mutation is only safe when the array is a private local with no caller relying on a fresh reference.


### PR DESCRIPTION
## Summary

Brings the documentation in line with the full set of performance principles actually applied in #419 (perf hot-path pass). Performance is a primary, non-negotiable goal of the library, and the docs previously captured only a subset of the rules we now follow.

## Changes

- **AGENTS.md → Performance**: expanded the concrete-rules list to cover everything used in #419 — spread (incl. `fn(...arr)` / `push(...arr)`) → `concat`/`slice`; `for…of`/`forEach` → indexed `for`; `includes`/`indexOf`/`find` → `Set`/`Map`; `codePointAt` → `charCodeAt` for ASCII/surrogate scans; hoisting constants + regex compilation; in-place mutation over allocating `concat`/`filter`; single-value resolution over merged-object builds; closures-in-hot-loops. Documented the lint carve-out policy (now including `unicorn/prefer-code-point`) and the behavior-preservation requirement. Added a pointer to the worked examples.
- **docs/conventions.md → Performance** (new section): before/after code examples for each principle, in the style of the rest of the conventions doc, cross-referencing AGENTS.md as the authoritative rule list.

## Notes

Docs-only change. `npm run check` clean. No code touched, so no behavioral risk; skipping the Codex review pass (docs-only).
