### PR TITLE
chore: re-enable 10 oxlint rules from the TODO backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ const validator = ZSchema.create(); // returns ZSchema
 try {
   validator.validate(json, schema); // returns true
 } catch (error) {
-  console.log(error.name); // 'z-schema validation error'
+  console.log(error.name); // 'ValidateError'
   console.log(error.message); // summary message
   console.log(error.details); // array of { code, message, path, ... }
 }

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -41,5 +41,5 @@ Line coverage status: **high**
 | src/z-schema-options.ts       |     92% |         92% |       100% |      70% |
 | src/z-schema-reader.ts        |    100% |        100% |       100% |     100% |
 | src/z-schema-versions.ts      |    100% |        100% |       100% |      75% |
-| src/z-schema.ts               |     74% |         75% |        79% |     100% |
+| src/z-schema.ts               |     76% |         76% |        79% |     100% |
 | **Total**                     | **90%** |     **90%** |    **95%** |  **88%** |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,7 +59,7 @@ try {
   validator.validate(data, schema);
   // validation passed — returns true
 } catch (err) {
-  console.log(err.name); // 'z-schema validation error'
+  console.log(err.name); // 'ValidateError'
   console.log(err.message); // summary message
   console.log(err.details); // SchemaErrorDetail[]
 }
@@ -151,7 +151,7 @@ validator.validate({ name: 'Alice', age: 30 }, 'person');
 
 `ValidateError` (thrown or returned) has:
 
-- `.name` — `'z-schema validation error'`
+- `.name` — `'ValidateError'`
 - `.message` — summary string
 - `.details` — array of `SchemaErrorDetail`:
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -55,6 +55,12 @@ export default defineConfig({
     // need on these hot per-character paths.
     'unicorn/prefer-code-point': 'off',
 
+    // Parameterless Array#sort over string keys uses native lexicographic
+    // comparison — faster than, and identical to, a JS comparator on the clone
+    // hot path (utils/clone.ts shallowClone/deepClone key ordering). Enabling the
+    // rule would force a per-comparison JS callback for no functional gain.
+    'unicorn/no-array-sort': 'off',
+
     // ── TODO: rules from the ultracite preset currently reporting errors ──
     // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
 
@@ -203,22 +209,6 @@ export default defineConfig({
     'typescript/no-unsafe-assignment': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 9
-    // complexity: moderate
-    // Variable names shadow outer-scope variables; renaming requires confirming no semantic collision exists.
-    // type: bug-prevention
-    // Disallows variable declarations that shadow variables declared in outer scopes.
-    'no-shadow': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 8
-    // complexity: moderate
-    // `Array.prototype.sort()` is called without a comparator, which has locale-dependent behaviour; each call site needs an explicit comparator.
-    // type: bug-prevention
-    // Disallows calling `Array.prototype.sort()` without a comparator function to avoid non-deterministic sort order.
-    'unicorn/no-array-sort': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 8
     // complexity: moderate
     // `new Promise()` constructors are used in places where an existing promise-returning API could be used directly.
@@ -244,27 +234,11 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 3
-    // complexity: moderate
-    // TypeScript parameter properties (shorthand constructor `private x`) are used; converting to explicit properties requires structural changes.
-    // type: style
-    // Disallows TypeScript parameter property syntax in constructors, requiring explicit class property declarations.
-    'typescript/parameter-properties': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
     // complexity: dangerous
     // Functions return `any`-typed values where a typed return is expected; fixing requires narrowing the returned types.
     // type: type-safety
     // Disallows returning `any`-typed values from functions with non-`any` return type annotations.
     'typescript/no-unsafe-return': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
-    // complexity: moderate
-    // Error-first callbacks are used but the error argument is not checked before proceeding; each site requires an explicit error guard.
-    // type: bug-prevention
-    // Requires error-first callback parameters to be handled (checked or re-thrown) rather than silently ignored.
-    'node/handle-callback-err': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
@@ -285,26 +259,10 @@ export default defineConfig({
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
     // complexity: moderate
-    // Functions annotated with a `void` return type return a value in some code paths; requires auditing intent.
-    // type: type-safety
-    // Disallows returning a value from a function whose return type is `void`.
-    'typescript/strict-void-return': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: moderate
     // `return await promise` is used inside `async` functions where `return promise` would be equivalent; however changing it can alter stack trace and try/catch semantics.
     // type: best-practice
     // Requires or disallows `return await` inside `async` functions; the preferred form depends on stack-trace and error-propagation needs.
     'typescript/return-await': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: moderate
-    // A `void`-typed expression is used in a non-void context (e.g., passed as a value); restructuring is required to avoid the confusion.
-    // type: type-safety
-    // Disallows using expressions of type `void` in positions where a non-void value is expected.
-    'typescript/no-confusing-void-expression': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
@@ -316,43 +274,11 @@ export default defineConfig({
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
-    // complexity: trivial
-    // A variable is immediately mutated after declaration (e.g., `const x = []; x.push(y)`); initialise directly instead.
-    // type: style
-    // Disallows immediately mutating a variable after its initial declaration/assignment.
-    'unicorn/no-immediate-mutation': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: moderate
-    // A custom `Error` subclass does not follow the expected pattern (name property, correct prototype chain); refactoring requires care.
-    // type: best-practice
-    // Enforces that custom `Error` subclasses are defined correctly (set `name`, use `super()`, etc.).
-    'unicorn/custom-error-definition': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: moderate
-    // A `+` operation mixes string and non-string operands in a way that TypeScript considers unsafe; explicit conversion is needed.
-    // type: type-safety
-    // Disallows the `+` operator when its operands have types that could produce an unintended string/number concatenation.
-    'typescript/restrict-plus-operands': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
     // complexity: dangerous
     // A promise is created but not `await`ed or `.catch()`ed, meaning rejection errors would be silently swallowed.
     // type: bug-prevention
     // Disallows floating (unhandled) promises — promises that are neither awaited nor explicitly handled with `.catch()`.
     'typescript/no-floating-promises': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: moderate
-    // A `.then()` chain is nested inside another `.then()`, creating a promise nesting anti-pattern; flattening requires refactoring.
-    // type: best-practice
-    // Disallows nesting promise `.then()` callbacks inside other `.then()` callbacks.
-    'promise/no-nesting': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1
@@ -377,7 +303,7 @@ export default defineConfig({
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 5
     // complexity: moderate
-    // Functions mix value-returning and bare `return`/fall-through paths; normalising requires auditing each branch.
+    // Conflicts with the enabled `unicorn/no-useless-undefined`: functions returning `T | undefined` cannot satisfy both (this rule wants `return undefined;`, the other forbids it). Deferred until that tension is resolved.
     // type: bug-prevention
     // Requires functions to either always or never return a value (no implicit `undefined` on some paths).
     'typescript/consistent-return': 'off',
@@ -389,14 +315,6 @@ export default defineConfig({
     // type: bug-prevention
     // Requires Promise rejection reasons to be Error objects.
     'typescript/prefer-promise-reject-errors': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: moderate
-    // A generic type parameter is used only once and could be inlined; removing it changes the signature.
-    // type: maintainability
-    // Flags type parameters that appear only once and therefore add no genuine genericity.
-    'typescript/no-unnecessary-type-parameters': 'off',
   },
   overrides: [
     {

--- a/skills/handling-validation-errors/SKILL.md
+++ b/skills/handling-validation-errors/SKILL.md
@@ -16,11 +16,11 @@ import type { SchemaErrorDetail } from 'z-schema';
 
 `ValidateError` extends `Error`:
 
-| Property   | Type                  | Description                          |
-| ---------- | --------------------- | ------------------------------------ |
-| `.name`    | `string`              | Always `'z-schema validation error'` |
-| `.message` | `string`              | Summary message                      |
-| `.details` | `SchemaErrorDetail[]` | All individual errors                |
+| Property   | Type                  | Description              |
+| ---------- | --------------------- | ------------------------ |
+| `.name`    | `string`              | Always `'ValidateError'` |
+| `.message` | `string`              | Summary message          |
+| `.details` | `SchemaErrorDetail[]` | All individual errors    |
 
 Each `SchemaErrorDetail`:
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -76,12 +76,11 @@ export const Errors = {
 };
 
 export class ValidateError extends Error {
-  name: string;
+  override readonly name: string = 'ValidateError';
   details?: SchemaErrorDetail[];
 
   constructor(message: string, details?: SchemaErrorDetail[]) {
     super(message);
-    this.name = 'z-schema validation error';
     this.details = details;
   }
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -121,7 +121,7 @@ export class Report {
     return this.errors.length === 0;
   }
 
-  addAsyncTask<FV, FN extends (...args: any[]) => FV>(
+  addAsyncTask<FN extends (...args: any[]) => any>(
     fn: FN,
     args: Parameters<FN>,
     asyncTaskResultProcessFn: (result: ReturnType<FN>) => void
@@ -329,7 +329,7 @@ export class Report {
       errorMessage = errorMessage.replace(`{${idx}}`, param.toString());
     }
 
-    const err: SchemaErrorDetail = {
+    const err = {
       code: errorCode,
       params,
       message: errorMessage,
@@ -337,10 +337,9 @@ export class Report {
       schemaPath: this.getSchemaPath(),
       schemaId: this.getSchemaId(),
       keyword,
-    };
-
-    (err as any)[schemaSymbol] = schema;
-    (err as any)[jsonSymbol] = this.getJson();
+      [schemaSymbol]: schema,
+      [jsonSymbol]: this.getJson(),
+    } as SchemaErrorDetail;
 
     if (schema && typeof schema === 'string') {
       err.description = schema;

--- a/src/schema-cache.ts
+++ b/src/schema-cache.ts
@@ -60,8 +60,11 @@ export function prepareRemoteSchema(
 export class SchemaCache {
   static global_cache: SchemaCacheStorage = Object.create(null);
   cache: SchemaCacheStorage = Object.create(null);
+  private readonly validator: ZSchemaBase;
 
-  constructor(private readonly validator: ZSchemaBase) {}
+  constructor(validator: ZSchemaBase) {
+    this.validator = validator;
+  }
 
   static cacheSchemaByUri(uri: string, schema: JsonSchemaInternal) {
     const remotePath = getSafeRemotePath(uri);

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -289,7 +289,11 @@ const resolveSchemaScopeId = (base: string | undefined, schema: JsonSchemaIntern
 };
 
 export class SchemaCompiler {
-  constructor(private readonly validator: ZSchemaBase) {}
+  private readonly validator: ZSchemaBase;
+
+  constructor(validator: ZSchemaBase) {
+    this.validator = validator;
+  }
 
   collectAndCacheIds(schema: JsonSchemaInternal) {
     const ids = collectIds(schema, this.validator.options.maxRecursionDepth);

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -692,7 +692,11 @@ const SchemaValidators = {
 } as const;
 
 export class SchemaValidator {
-  constructor(private readonly validator: ZSchemaBase) {}
+  private readonly validator: ZSchemaBase;
+
+  constructor(validator: ZSchemaBase) {
+    this.validator = validator;
+  }
 
   get options() {
     return this.validator.options;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -7,7 +7,7 @@ import { areEqual } from './json.js';
  * Falls back to pairwise deep comparison (O(n²)) when the array contains
  * objects or arrays that need structural equality checks.
  */
-export const isUniqueArray = <T>(arr: T[], indexes?: number[], maxDepth?: number): boolean => {
+export const isUniqueArray = (arr: unknown[], indexes?: number[], maxDepth?: number): boolean => {
   const l = arr.length;
   if (l <= 1) {
     return true;

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -25,9 +25,9 @@ export const deepClone = <T>(src: T, maxDepth = DEFAULT_MAX_RECURSION_DEPTH): T 
   let vidx = 0;
   const visited = new Map();
   const cloned: any[] = [];
-  const cloneDeepInner = <T>(src: T, _depth: number): T => {
-    if (typeof src !== 'object' || src === null) {
-      return src;
+  const cloneDeepInner = <U>(node: U, _depth: number): U => {
+    if (typeof node !== 'object' || node === null) {
+      return node;
     }
 
     if (_depth >= maxDepth) {
@@ -38,25 +38,25 @@ export const deepClone = <T>(src: T, maxDepth = DEFAULT_MAX_RECURSION_DEPTH): T 
     }
 
     let res: any;
-    const cidx = visited.get(src);
+    const cidx = visited.get(node);
 
     if (cidx !== undefined) {
       return cloned[cidx];
     }
 
-    visited.set(src, vidx++);
-    if (Array.isArray(src)) {
+    visited.set(node, vidx++);
+    if (Array.isArray(node)) {
       res = [];
       cloned.push(res);
-      for (let i = 0; i < src.length; i++) {
-        res[i] = cloneDeepInner(src[i], _depth + 1);
+      for (let i = 0; i < node.length; i++) {
+        res[i] = cloneDeepInner(node[i], _depth + 1);
       }
     } else {
       res = {};
       cloned.push(res);
-      const keys = Object.keys(src).sort() as Array<keyof T>;
+      const keys = Object.keys(node).sort() as Array<keyof U>;
       for (let i = 0; i < keys.length; i++) {
-        copyProp(src, res, keys[i], (v: any) => cloneDeepInner(v, _depth + 1));
+        copyProp(node, res, keys[i], (v: any) => cloneDeepInner(v, _depth + 1));
       }
     }
     return res;

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -88,7 +88,7 @@ export function additionalPropertiesValidator(
 ) {
   // covered in properties and patternProperties
   if (schema.properties === undefined && schema.patternProperties === undefined) {
-    return propertiesValidator.call(this, report, schema, json);
+    propertiesValidator.call(this, report, schema, json);
   }
 }
 
@@ -104,7 +104,7 @@ export function patternPropertiesValidator(
 ) {
   // covered in properties
   if (schema.properties === undefined) {
-    return propertiesValidator.call(this, report, schema, json);
+    propertiesValidator.call(this, report, schema, json);
   }
 }
 

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -263,8 +263,8 @@ export class ZSchemaBase {
     }
     const details = err.details || [];
     const missingRefs: string[] = [];
-    function collect(details: SchemaErrorDetail[]) {
-      for (const detail of details) {
+    function collect(items: SchemaErrorDetail[]) {
+      for (const detail of items) {
         if (detail.code === 'UNRESOLVABLE_REFERENCE' || detail.code === 'SCHEMA_NOT_REACHABLE') {
           missingRefs.push(detail.params[0] as string);
         }
@@ -314,36 +314,36 @@ export class ZSchemaBase {
     const visited = new WeakSet<object>();
 
     // clean-up the schema and resolve references
-    const cleanup = (schema: any) => {
+    const cleanup = (node: any) => {
       let key;
-      const typeOf = whatIs(schema);
+      const typeOf = whatIs(node);
       if (typeOf !== 'object' && typeOf !== 'array') {
         return;
       }
 
-      if (visited.has(schema)) {
+      if (visited.has(node)) {
         return;
       }
 
-      visited.add(schema);
+      visited.add(node);
 
-      if (schema.$ref && schema.__$refResolved) {
-        const from = schema.__$refResolved;
-        const to = schema;
-        delete schema.$ref;
-        delete schema.__$refResolved;
+      if (node.$ref && node.__$refResolved) {
+        const from = node.__$refResolved;
+        const to = node;
+        delete node.$ref;
+        delete node.__$refResolved;
         for (key in from) {
           if (Object.hasOwn(from, key)) {
             copyProp(from, to, key);
           }
         }
       }
-      for (key in schema) {
-        if (Object.hasOwn(schema, key)) {
+      for (key in node) {
+        if (Object.hasOwn(node, key)) {
           if (isInternalKey(key)) {
-            delete schema[key];
+            delete node[key];
           } else {
-            cleanup(schema[key]);
+            cleanup(node[key]);
           }
         }
       }

--- a/src/z-schema.ts
+++ b/src/z-schema.ts
@@ -25,7 +25,7 @@ export class ZSchema extends ZSchemaBase {
    * @param validatorFunction - A sync or async function `(value: unknown) => boolean | Promise<boolean>`.
    */
   public static registerFormat(name: string, validatorFunction: FormatValidatorFn): void {
-    return registerFormat(name, validatorFunction);
+    registerFormat(name, validatorFunction);
   }
 
   /**
@@ -33,7 +33,7 @@ export class ZSchema extends ZSchemaBase {
    * @param name - The format name to unregister.
    */
   public static unregisterFormat(name: string): void {
-    return unregisterFormat(name);
+    unregisterFormat(name);
   }
 
   /** Returns the names of all globally registered format validators. */
@@ -67,7 +67,7 @@ export class ZSchema extends ZSchemaBase {
    * @param schemaReader - A function `(uri: string) => JsonSchema | undefined`, or `undefined` to clear.
    */
   public static setSchemaReader(schemaReader: SchemaReader | undefined) {
-    return setSchemaReader(schemaReader);
+    setSchemaReader(schemaReader);
   }
 
   public static schemaSymbol = schemaSymbol;
@@ -159,7 +159,13 @@ export class ZSchema extends ZSchemaBase {
   validateAsync(json: unknown, schema: JsonSchema | string, options?: ValidateOptions): Promise<true> {
     return new Promise((resolve, reject) => {
       try {
-        this._validate(json, schema, options || {}, (err, valid) => (err || !valid ? reject(err) : resolve(valid)));
+        this._validate(json, schema, options || {}, (err, valid) => {
+          if (err || !valid) {
+            reject(err);
+          } else {
+            resolve(valid);
+          }
+        });
       } catch (error) {
         reject(error);
       }
@@ -263,7 +269,13 @@ export class ZSchemaAsync extends ZSchemaBase {
   validate(json: unknown, schema: JsonSchema | string, options: ValidateOptions = {}): Promise<true> {
     return new Promise((resolve, reject) => {
       try {
-        this._validate(json, schema, options, (err, valid) => (err || !valid ? reject(err) : resolve(valid)));
+        this._validate(json, schema, options, (err, valid) => {
+          if (err || !valid) {
+            reject(err);
+          } else {
+            resolve(valid);
+          }
+        });
       } catch (error) {
         reject(error);
       }

--- a/test/ZSchemaTestSuite/CustomFormats.ts
+++ b/test/ZSchemaTestSuite/CustomFormats.ts
@@ -54,7 +54,7 @@ export default {
         format: 'fillHello',
       },
       valid: true,
-      after(err: any, valid: any, obj: any) {
+      after(_err: any, valid: any, obj: any) {
         expect(obj.hello).toBe('world');
       },
     },

--- a/test/ZSchemaTestSuite/Issue102.ts
+++ b/test/ZSchemaTestSuite/Issue102.ts
@@ -6,7 +6,7 @@ export default {
       schema: {},
       data: {},
       valid: true,
-      after(err: any, valid: any, data: any, validator: any) {
+      after(_err: any, valid: any, data: any, validator: any) {
         validator.getResolvedSchema('http://json-schema.org/draft-04/schema#');
       },
     },

--- a/test/ZSchemaTestSuite/Issue94.ts
+++ b/test/ZSchemaTestSuite/Issue94.ts
@@ -34,7 +34,7 @@ export default {
       schema: [schema1, schema2],
       validateSchemaOnly: true,
       valid: true,
-      after(err: any, valid: any, data: any, validator: any) {
+      after(_err: any, valid: any, data: any, validator: any) {
         const newSch = validator.getResolvedSchema('person-object');
         expect(isequal(newSch, expectedResult)).toBe(true);
       },

--- a/test/spec/automatic-schema-loading.spec.ts
+++ b/test/spec/automatic-schema-loading.spec.ts
@@ -23,19 +23,21 @@ function validateWithAutomaticDownloads(
     const missingReferences = result.valid ? [] : validator.getMissingRemoteReferences(result.err!);
     if (missingReferences.length > 0) {
       let finished = 0;
-      missingReferences.forEach(function (url: string) {
-        fetch(url).then(async (res) => {
-          if (!res.ok) {
-            const text = await res.text().catch(() => '');
-            throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
-          }
-          const json = await res.json();
-          validator.setRemoteReference(url, json);
-          finished++;
-          if (finished === missingReferences.length) {
-            validate();
-          }
-        });
+      const loadReference = async (url: string) => {
+        const res = await fetch(url);
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          throw new Error(`HTTP ${res.status} ${res.statusText}: ${text}`);
+        }
+        const json = await res.json();
+        validator.setRemoteReference(url, json);
+        finished++;
+        if (finished === missingReferences.length) {
+          validate();
+        }
+      };
+      missingReferences.forEach((url: string) => {
+        void loadReference(url);
       });
     } else {
       finish();

--- a/test/spec/schema-path.spec.ts
+++ b/test/spec/schema-path.spec.ts
@@ -82,7 +82,7 @@ describe('Using path to schema as a third argument', function () {
 describe('Schema path tracking in validation errors', function () {
   it('should include schema path for property type validation', function () {
     const validator = ZSchema.create({ reportPathAsArray: true });
-    const schema = {
+    const testSchema = {
       type: 'object',
       properties: {
         name: { type: 'string' },
@@ -92,7 +92,7 @@ describe('Schema path tracking in validation errors', function () {
     const data = { name: 'John', age: 'thirty' };
 
     try {
-      validator.validate(data, schema);
+      validator.validate(data, testSchema);
       expect.fail('Validation should have failed');
     } catch (error: any) {
       expect(error.details).toHaveLength(1);
@@ -103,14 +103,14 @@ describe('Schema path tracking in validation errors', function () {
 
   it('should include schema path for array item validation', function () {
     const validator = ZSchema.create({ reportPathAsArray: true });
-    const schema = {
+    const testSchema = {
       type: 'array',
       items: { type: 'string' },
     };
     const data = ['valid', 123, 'also-valid'];
 
     try {
-      validator.validate(data, schema);
+      validator.validate(data, testSchema);
       expect.fail('Validation should have failed');
     } catch (error: any) {
       expect(error.details).toHaveLength(1);
@@ -121,7 +121,7 @@ describe('Schema path tracking in validation errors', function () {
 
   it('should include schema path for nested object validation', function () {
     const validator = ZSchema.create({ reportPathAsArray: true });
-    const schema = {
+    const testSchema = {
       type: 'object',
       properties: {
         user: {
@@ -136,7 +136,7 @@ describe('Schema path tracking in validation errors', function () {
     const data = { user: { name: 'John', age: 'thirty' } };
 
     try {
-      validator.validate(data, schema);
+      validator.validate(data, testSchema);
       expect.fail('Validation should have failed');
     } catch (error: any) {
       expect(error.details).toHaveLength(1);
@@ -147,11 +147,11 @@ describe('Schema path tracking in validation errors', function () {
 
   it('should handle root level type validation', function () {
     const validator = ZSchema.create({ reportPathAsArray: true });
-    const schema = { type: 'string' };
+    const testSchema = { type: 'string' };
     const data = 123;
 
     try {
-      validator.validate(data, schema);
+      validator.validate(data, testSchema);
       expect.fail('Validation should have failed');
     } catch (error: any) {
       expect(error.details).toHaveLength(1);
@@ -162,7 +162,7 @@ describe('Schema path tracking in validation errors', function () {
 
   it('should include schema path for $ref validation', function () {
     const validator = ZSchema.create({ reportPathAsArray: true });
-    const schema = {
+    const testSchema = {
       type: 'object',
       properties: {
         user: { $ref: '#/definitions/User' },
@@ -180,7 +180,7 @@ describe('Schema path tracking in validation errors', function () {
     const data = { user: { name: 'John', age: 'thirty' } };
 
     try {
-      validator.validate(data, schema);
+      validator.validate(data, testSchema);
       expect.fail('Validation should have failed');
     } catch (error: any) {
       expect(error.details).toHaveLength(1);

--- a/test/spec/utils.clone.spec.ts
+++ b/test/spec/utils.clone.spec.ts
@@ -5,7 +5,7 @@ import { deepClone, shallowClone } from '../../src/utils/clone.ts';
 describe('shallowClone', () => {
   it('should return primitive values unchanged', () => {
     expect(shallowClone(null)).toBe(null);
-    // eslint-disable-next-line unicorn/no-useless-undefined -- explicitly testing the undefined input
+    // eslint-disable-next-line unicorn/no-useless-undefined, typescript/no-confusing-void-expression -- explicitly testing the undefined input value
     expect(shallowClone(undefined)).toBe(undefined);
     expect(shallowClone(42)).toBe(42);
     expect(shallowClone('hello')).toBe('hello');
@@ -49,7 +49,7 @@ describe('shallowClone', () => {
 describe('deepClone', () => {
   it('should return primitive values unchanged', () => {
     expect(deepClone(null)).toBe(null);
-    // eslint-disable-next-line unicorn/no-useless-undefined -- explicitly testing the undefined input
+    // eslint-disable-next-line unicorn/no-useless-undefined, typescript/no-confusing-void-expression -- explicitly testing the undefined input value
     expect(deepClone(undefined)).toBe(undefined);
     expect(deepClone(42)).toBe(42);
     expect(deepClone('hello')).toBe('hello');


### PR DESCRIPTION
## Summary

Continues the oxlint TODO-backlog reduction (cf. #418–#422): re-enables **10** preset rules and fixes all their violations. All changes are behavior-preserving except the documented `ValidateError.name` change (see below).

### Rules re-enabled (10)

| Rule | Fix |
|------|-----|
| `typescript/parameter-properties` | constructor shorthand → explicit field (`schema-cache`, `schema-compiler`, `schema-validator`) |
| `typescript/no-unnecessary-type-parameters` | inline single-use generics (`utils/array`, `report`) |
| `no-shadow` | rename shadowing locals (`utils/clone`, `z-schema-base`, `schema-path.spec`) |
| `unicorn/no-immediate-mutation` | fold post-init symbol assignments into the literal (`report`) |
| `node/handle-callback-err` | mark unused `err` params (`ZSchemaTestSuite`) |
| `promise/no-nesting` | flatten nested `.then` to `await` (`automatic-schema-loading.spec`) |
| `typescript/no-confusing-void-expression` | don't `return` a `void` expression (`validation/object`, `z-schema`) |
| `unicorn/custom-error-definition` | set `name` to the class name (`errors`) |
| `typescript/restrict-plus-operands` | already clean — re-enabled, stale TODO removed |
| `typescript/strict-void-return` | already clean — re-enabled, stale TODO removed |

### ⚠️ Behavior change

`ValidateError.name` is now `'ValidateError'` (was `'z-schema validation error'`), required by `unicorn/custom-error-definition`. README, `docs/usage.md`, and the validation-errors skill are updated to match. No test relied on the old string.

### Performance

`unicorn/no-array-sort` is **not** re-enabled — it is relocated to the "intentionally kept off for performance" block. The parameterless `Array#sort` over string keys in the clone hot path (`utils/clone.ts`) uses native lexicographic comparison, which is faster than (and identical to) a JS comparator.

### Deferred

`typescript/consistent-return` was attempted but **deferred** (kept in the backlog with a rationale comment): it directly conflicts with the already-enabled `unicorn/no-useless-undefined` — for functions returning `T | undefined`, one rule demands `return undefined;` and the other forbids it.

## Verification

- `npm run check` — lint + format clean
- `npm run build` + `npm run build:tests` — clean
- `npm test` — **32389 tests pass** (node + browser), 0 failed
