### PR TITLE
chore: re-enable 8 oxlint rules from the TODO backlog

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -65,14 +65,6 @@ export default defineConfig({
     // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 171
-    // complexity: trivial
-    // Many function expressions lack names; adding names aids stack traces but is purely mechanical.
-    // type: maintainability
-    // Requires function expressions to have a name (aids debugging via named stack frames).
-    'func-names': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 105
     // complexity: dangerous
     // Member access on `any`-typed values is common in schema traversal code; fixing requires narrowing types or adding casts throughout.
@@ -87,14 +79,6 @@ export default defineConfig({
     // type: bug-prevention
     // Disallows `this` inside exported standalone functions where the `this` context is unpredictable.
     'oxc/no-this-in-exported-function': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 76
-    // complexity: trivial
-    // Anonymous function expressions are passed as callbacks; converting to arrow functions is mechanical.
-    // type: style
-    // Requires arrow functions in callback positions instead of traditional function expressions.
-    'prefer-arrow-callback': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 73
@@ -185,22 +169,6 @@ export default defineConfig({
     'unicorn/no-array-for-each': 'off',
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 12
-    // complexity: dangerous
-    // `async` functions contain no `await` expression; removing `async` or adding `await` may affect error-handling semantics.
-    // type: bug-prevention
-    // Disallows `async` functions that contain no `await` expression, which is usually unintentional.
-    'require-await': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 11
-    // complexity: moderate
-    // Functions defined inside other functions could be moved to an outer scope; refactoring requires verifying closure dependencies.
-    // type: maintainability
-    // Flags functions that can be moved to a higher scope, reducing closure overhead and improving readability.
-    'unicorn/consistent-function-scoping': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 11
     // complexity: dangerous
     // Values typed as `any` are assigned to typed variables; fixing requires narrowing the source types throughout the codebase.
@@ -243,42 +211,10 @@ export default defineConfig({
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 2
     // complexity: moderate
-    // CommonJS constructs (`require`, `module.exports`) are used; migrating to ESM requires coordinated changes and build-config updates.
-    // type: best-practice
-    // Requires ECMAScript module syntax (`import`/`export`) instead of CommonJS (`require`/`module.exports`).
-    'unicorn/prefer-module': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: moderate
     // An object has a `.then()` method which makes it thenable, potentially causing confusion with promises in `await` expressions.
     // type: bug-prevention
     // Disallows objects that define a `.then()` method in non-promise contexts, as they are mistakenly treated as thenables.
     'unicorn/no-thenable': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: moderate
-    // `return await promise` is used inside `async` functions where `return promise` would be equivalent; however changing it can alter stack trace and try/catch semantics.
-    // type: best-practice
-    // Requires or disallows `return await` inside `async` functions; the preferred form depends on stack-trace and error-propagation needs.
-    'typescript/return-await': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 2
-    // complexity: moderate
-    // A promise can be resolved or rejected multiple times in different branches; requires careful control-flow analysis per site.
-    // type: bug-prevention
-    // Disallows resolving or rejecting a promise more than once within a promise executor.
-    'promise/no-multiple-resolved': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 1
-    // complexity: dangerous
-    // A promise is created but not `await`ed or `.catch()`ed, meaning rejection errors would be silently swallowed.
-    // type: bug-prevention
-    // Disallows floating (unhandled) promises — promises that are neither awaited nor explicitly handled with `.catch()`.
-    'typescript/no-floating-promises': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 1

--- a/src/report.ts
+++ b/src/report.ts
@@ -218,7 +218,7 @@ export class Report {
     if (returnPathAsString !== true) {
       // Sanitize the path segments (http://tools.ietf.org/html/rfc6901#section-4)
       return `#/${path
-        .map(function (segment) {
+        .map((segment) => {
           segment = segment.toString();
 
           if (isAbsoluteUri(segment)) {

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -95,7 +95,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
     }
     if (formatValidatorFn.length === 2) {
       // callback-based async
-      report.addAsyncTaskWithPath(formatValidatorFn, [json], function (result) {
+      report.addAsyncTaskWithPath(formatValidatorFn, [json], (result) => {
         if (result !== true) {
           report.addError('INVALID_FORMAT', [schema.format!, JSON.stringify(json)], undefined, schema, 'format');
         }
@@ -115,7 +115,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
             }
           },
           [] as any,
-          function (resolvedResult) {
+          (resolvedResult) => {
             if (resolvedResult !== true) {
               report.addError('INVALID_FORMAT', [schema.format!, JSON.stringify(json)], undefined, schema, 'format');
             }

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -98,7 +98,7 @@ export class ZSchemaBase {
         `Invalid .validate call - schema must be a string or object but ${whatIs(schema)} was passed!`
       );
       if (callback) {
-        setTimeout(function () {
+        setTimeout(() => {
           callback(e, false);
         }, 0);
         return;
@@ -117,7 +117,7 @@ export class ZSchemaBase {
       if (!_schema) {
         const e = new Error(`Schema with id '${schemaName}' wasn't found in the validator cache!`);
         if (callback) {
-          setTimeout(function () {
+          setTimeout(() => {
             callback(e, false);
           }, 0);
           return;
@@ -150,7 +150,7 @@ export class ZSchemaBase {
       if (!_schema) {
         const e = new Error(`Schema path '${options.schemaPath}' wasn't found in the schema!`);
         if (callback) {
-          setTimeout(function () {
+          setTimeout(() => {
             callback(e, false);
           }, 0);
           return;

--- a/test/ZSchemaTestSuite/CustomFormats.ts
+++ b/test/ZSchemaTestSuite/CustomFormats.ts
@@ -2,13 +2,9 @@ export default {
   description: 'registerFormat - Custom formats support',
   version: 'draft-04',
   setup(validator: any, Class: any) {
-    Class.registerFormat('xstring', function (str: any) {
-      return str === 'xxx';
-    });
-    Class.registerFormat('emptystring', function (str: any) {
-      return typeof str === 'string' && str.length === 0 && str === '';
-    });
-    Class.registerFormat('fillHello', function (obj: any) {
+    Class.registerFormat('xstring', (str: any) => str === 'xxx');
+    Class.registerFormat('emptystring', (str: any) => typeof str === 'string' && str.length === 0 && str === '');
+    Class.registerFormat('fillHello', (obj: any) => {
       obj.hello = 'world';
       return true;
     });

--- a/test/ZSchemaTestSuite/CustomFormatsAsync.ts
+++ b/test/ZSchemaTestSuite/CustomFormatsAsync.ts
@@ -5,14 +5,12 @@ export default {
     asyncTimeout: 500,
   },
   setup(validator: any, Class: any) {
-    Class.registerFormat('xstring', function (str: any, callback: any) {
-      setTimeout(function () {
+    Class.registerFormat('xstring', (str: any, callback: any) => {
+      setTimeout(() => {
         callback(str === 'xxx');
       }, 1);
     });
-    Class.registerFormat('shouldTimeout', function (str: any, callback: any) {
-      return typeof callback === 'function';
-    });
+    Class.registerFormat('shouldTimeout', (str: any, callback: any) => typeof callback === 'function');
   },
   schema: {
     type: 'string',

--- a/test/ZSchemaTestSuite/Issue107.ts
+++ b/test/ZSchemaTestSuite/Issue107.ts
@@ -1,11 +1,9 @@
 export default {
   description: 'Issue #107 - add Support for Controlling Remote Schema Reading',
   setup(validator: any, ZSchema: any) {
-    ZSchema.setSchemaReader(function (_uri: any) {
-      return {
-        type: 'string',
-      };
-    });
+    ZSchema.setSchemaReader((_uri: any) => ({
+      type: 'string',
+    }));
   },
   tests: [
     {

--- a/test/ZSchemaTestSuite/Issue125.ts
+++ b/test/ZSchemaTestSuite/Issue125.ts
@@ -3,9 +3,7 @@
 export default {
   description: 'Issue #125 - Why process format if type validation fails',
   setup(validator: any, Class: any) {
-    Class.registerFormat('test', function (item: any) {
-      return typeof item === 'string';
-    });
+    Class.registerFormat('test', (item: any) => typeof item === 'string');
   },
   tests: [
     {

--- a/test/ZSchemaTestSuite/Issue126.ts
+++ b/test/ZSchemaTestSuite/Issue126.ts
@@ -31,7 +31,7 @@ export default {
       validateSchemaOnly: true,
       valid: false,
       after(err: any, valid: any, data: any, validator: any) {
-        err.forEach(function (e: any) {
+        err.forEach((e: any) => {
           if (e.params.includes(REF_NAME)) {
             expect(e.code).not.toBe('UNRESOLVABLE_REFERENCE');
           }

--- a/test/ZSchemaTestSuite/Issue130.ts
+++ b/test/ZSchemaTestSuite/Issue130.ts
@@ -32,7 +32,7 @@ export default {
       },
       valid: false,
       after(err: any) {
-        err.forEach(function (e: any) {
+        err.forEach((e: any) => {
           expect(e.path).toBe('#/this~1that/t~1h~1e~1 ~1o~1t~1h~1e~1r');
         });
       },

--- a/test/ZSchemaTestSuite/Issue139.ts
+++ b/test/ZSchemaTestSuite/Issue139.ts
@@ -47,7 +47,7 @@ export default {
       valid: false,
       after(err: any) {
         expect(err.length).toBe(3);
-        err.forEach(function (e: any) {
+        err.forEach((e: any) => {
           expect(e.code).toBe('UNRESOLVABLE_REFERENCE');
           expect(e.schemaId).toBe('dummy');
         });

--- a/test/ZSchemaTestSuite/Issue209.ts
+++ b/test/ZSchemaTestSuite/Issue209.ts
@@ -9,16 +9,14 @@ export default {
   setup(validator: any, Class: any) {
     if (testAsync) {
       // asynchronous validator
-      Class.registerFormat('string-length', function (str: any, callback: any) {
-        setTimeout(function () {
+      Class.registerFormat('string-length', (str: any, callback: any) => {
+        setTimeout(() => {
           callback(str.length > 10);
         }, 1);
       });
     } else {
       // same as above but synchronous (comment out the validator above and try with this instead)
-      Class.registerFormat('string-length', function (str: any) {
-        return str.length > 10;
-      });
+      Class.registerFormat('string-length', (str: any) => str.length > 10);
     }
   },
   schema: {

--- a/test/ZSchemaTestSuite/Issue57.ts
+++ b/test/ZSchemaTestSuite/Issue57.ts
@@ -548,12 +548,8 @@ const apiDeclarationJson = {
 export default {
   description: 'Issue #57 - maximum call stack exceeded error',
   setup(validator: any, Class: any) {
-    Class.registerFormat('mime-type', function () {
-      return true;
-    });
-    Class.registerFormat('uri-template', function () {
-      return true;
-    });
+    Class.registerFormat('mime-type', () => true);
+    Class.registerFormat('uri-template', () => true);
   },
   tests: [
     {

--- a/test/ZSchemaTestSuite/Issue67.ts
+++ b/test/ZSchemaTestSuite/Issue67.ts
@@ -4,9 +4,7 @@ export default {
     {
       description: 'should pass validation #1',
       setup(validator: any, Class: any) {
-        Class.registerFormat('not-blank', function () {
-          return true;
-        });
+        Class.registerFormat('not-blank', () => true);
       },
       schema: [
         {

--- a/test/ZSchemaTestSuite/getRegisteredFormats.ts
+++ b/test/ZSchemaTestSuite/getRegisteredFormats.ts
@@ -1,11 +1,7 @@
-'use strict';
-
 export default {
   description: 'getRegisteredFormats - return an array of format names',
   setup(validator: any, Class: any) {
-    Class.registerFormat('phone', function (_str: any) {
-      return true;
-    });
+    Class.registerFormat('phone', (_str: any) => true);
   },
 
   tests: [

--- a/test/lib/create-manifest.ts
+++ b/test/lib/create-manifest.ts
@@ -10,7 +10,7 @@ const getJsonFiles = async (directory: string, base: string): Promise<string[]> 
     entries.map(async (entry: any) => {
       const fullPath = join(directory, entry.name);
       if (entry.isDirectory()) {
-        return getJsonFiles(fullPath, base);
+        return await getJsonFiles(fullPath, base);
       }
       if (entry.isFile() && entry.name.endsWith('.json')) {
         return `/${relative(base, fullPath).replaceAll('\\', '/')}`;

--- a/test/spec/async-validation-example.spec.ts
+++ b/test/spec/async-validation-example.spec.ts
@@ -3,35 +3,35 @@ import { describe, expect, it } from 'vitest';
 import { ValidateError } from '../../src/index.ts';
 import { ZSchema } from '../../src/z-schema.ts';
 
+// Mock functions for testing
+const mockDatabaseCheck = (userId: string): Promise<boolean> => {
+  const validUsers = ['user123', 'user456'];
+  return Promise.resolve(validUsers.includes(userId));
+};
+
+const mockPostcodeCheck = (postcode: string): Promise<boolean> => {
+  const validPostcodes = ['SW1A 1AA', 'B1 1AA'];
+  return Promise.resolve(validPostcodes.includes(postcode));
+};
+
 describe('Async Validation Example', () => {
-  // Mock functions for testing
-  const mockDatabaseCheck = async (userId: string): Promise<boolean> => {
-    const validUsers = ['user123', 'user456'];
-    return validUsers.includes(userId);
-  };
-
-  const mockPostcodeCheck = async (postcode: string): Promise<boolean> => {
-    const validPostcodes = ['SW1A 1AA', 'B1 1AA'];
-    return validPostcodes.includes(postcode);
-  };
-
   const phoneRegex = /^\+?[1-9]\d{1,14}$/;
 
   const registerFormats = (validator: {
     registerFormat: (name: string, validatorFunction: (input: unknown) => boolean | Promise<boolean>) => void;
   }) => {
-    validator.registerFormat('user-exists', async (input: unknown): Promise<boolean> => {
+    validator.registerFormat('user-exists', (input: unknown): Promise<boolean> => {
       if (typeof input !== 'string') {
-        return false;
+        return Promise.resolve(false);
       }
-      return await mockDatabaseCheck(input);
+      return mockDatabaseCheck(input);
     });
 
-    validator.registerFormat('valid-postcode', async (input: unknown): Promise<boolean> => {
+    validator.registerFormat('valid-postcode', (input: unknown): Promise<boolean> => {
       if (typeof input !== 'string') {
-        return false;
+        return Promise.resolve(false);
       }
-      return await mockPostcodeCheck(input);
+      return mockPostcodeCheck(input);
     });
 
     validator.registerFormat('phone-number', (input: unknown): boolean => {
@@ -238,15 +238,16 @@ describe('Async Validation Example', () => {
       // For this test, we can mock a failing database check
       const validator = ZSchema.create();
 
+      // eslint-disable-next-line require-await -- intentionally async: models an async format validator that rejects (vs. a synchronous throw)
       validator.registerFormat('user-exists', async (): Promise<boolean> => {
         throw new Error('Database unavailable');
       });
 
-      validator.registerFormat('valid-postcode', async (input: unknown): Promise<boolean> => {
+      validator.registerFormat('valid-postcode', (input: unknown): Promise<boolean> => {
         if (typeof input !== 'string') {
-          return false;
+          return Promise.resolve(false);
         }
-        return await mockPostcodeCheck(input);
+        return mockPostcodeCheck(input);
       });
 
       validator.registerFormat('phone-number', (input: unknown): boolean => {

--- a/test/spec/async-validation.node-spec.ts
+++ b/test/spec/async-validation.node-spec.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from 'vitest';
 
 import { ZSchema } from '../../src/z-schema.js';
 
+const asyncValidValid = (input: unknown): Promise<boolean> =>
+  Promise.resolve(typeof input === 'string' && input === 'valid');
+
+const syncValidatorSyncValid = (input: unknown): boolean => typeof input === 'string' && input === 'sync-valid';
+
+const asyncValidAsyncValid = (input: unknown): Promise<boolean> =>
+  Promise.resolve(typeof input === 'string' && input === 'async-valid');
+
 describe('Async Format Validation Integration', () => {
   it('should validate successfully with async format validator', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => typeof input === 'string' && input === 'valid';
-
-    validator.registerFormat('async-check', asyncValidator);
+    validator.registerFormat('async-check', asyncValidValid);
 
     const schema = {
       type: 'string',
@@ -23,9 +29,7 @@ describe('Async Format Validation Integration', () => {
   it('should fail validation with async format validator', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> => typeof input === 'string' && input === 'valid';
-
-    validator.registerFormat('async-check', asyncValidator);
+    validator.registerFormat('async-check', asyncValidValid);
 
     const schema = {
       type: 'string',
@@ -40,13 +44,8 @@ describe('Async Format Validation Integration', () => {
   it('should work with async format validators in oneOf', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const syncValidator = (input: unknown): boolean => typeof input === 'string' && input === 'sync-valid';
-
-    const asyncValidator = async (input: unknown): Promise<boolean> =>
-      typeof input === 'string' && input === 'async-valid';
-
-    validator.registerFormat('sync-check', syncValidator);
-    validator.registerFormat('async-check', asyncValidator);
+    validator.registerFormat('sync-check', syncValidatorSyncValid);
+    validator.registerFormat('async-check', asyncValidAsyncValid);
 
     const schema = {
       oneOf: [
@@ -64,10 +63,7 @@ describe('Async Format Validation Integration', () => {
   it('should work with async format validators in anyOf', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> =>
-      typeof input === 'string' && input === 'async-valid';
-
-    validator.registerFormat('async-check', asyncValidator);
+    validator.registerFormat('async-check', asyncValidAsyncValid);
 
     const schema = {
       anyOf: [{ type: 'number' }, { type: 'string', format: 'async-check' }],
@@ -82,10 +78,7 @@ describe('Async Format Validation Integration', () => {
   it('should fail validation when async format validator in oneOf fails', async () => {
     const validator = ZSchema.create({ async: true, safe: true });
 
-    const asyncValidator = async (input: unknown): Promise<boolean> =>
-      typeof input === 'string' && input === 'async-valid';
-
-    validator.registerFormat('async-check', asyncValidator);
+    validator.registerFormat('async-check', asyncValidAsyncValid);
 
     const schema = {
       oneOf: [{ type: 'string', format: 'async-check' }, { type: 'number' }],

--- a/test/spec/automatic-schema-loading.spec.ts
+++ b/test/spec/automatic-schema-loading.spec.ts
@@ -47,9 +47,9 @@ function validateWithAutomaticDownloads(
   validate();
 }
 
-describe('Automatic schema loading', function () {
-  it('should download schemas and validate successfully', function () {
-    return new Promise<void>((resolve) => {
+describe('Automatic schema loading', () => {
+  it('should download schemas and validate successfully', () =>
+    new Promise<void>((resolve) => {
       if (isBrowser) {
         // skip this test in browsers
         expect(1).toBe(1);
@@ -61,16 +61,15 @@ describe('Automatic schema loading', function () {
       const schema = { $ref: 'http://json-schema.org/draft-04/schema#' };
       const data = { minLength: 1 };
 
-      validateWithAutomaticDownloads(validator, data, schema, function (err: unknown, valid: boolean) {
+      validateWithAutomaticDownloads(validator, data, schema, (err: unknown, valid: boolean) => {
         expect(valid).toBe(true);
         expect(err).toBe(null);
         resolve();
       });
-    });
-  });
+    }));
 
-  it('should download schemas and fail validating', function () {
-    return new Promise<void>((resolve) => {
+  it('should download schemas and fail validating', () =>
+    new Promise<void>((resolve) => {
       if (typeof window !== 'undefined') {
         // skip this test in browsers
         expect(1).toBe(1);
@@ -82,11 +81,10 @@ describe('Automatic schema loading', function () {
       const schema = { $ref: 'http://json-schema.org/draft-04/schema#' };
       const data = { minLength: -1 };
 
-      validateWithAutomaticDownloads(validator, data, schema, function (err: unknown, valid: boolean) {
+      validateWithAutomaticDownloads(validator, data, schema, (err: unknown, valid: boolean) => {
         expect(valid).toBe(false);
         expect((err as any)[0].code).toBe('MINIMUM');
         resolve();
       });
-    });
-  });
+    }));
 });

--- a/test/spec/build-artifacts.node-spec.ts
+++ b/test/spec/build-artifacts.node-spec.ts
@@ -1,17 +1,17 @@
 import fs from 'fs';
 
-describe('Build artifacts', function () {
-  it('creates ESM output', function () {
+describe('Build artifacts', () => {
+  it('creates ESM output', () => {
     expect(fs.existsSync('dist/index.js')).toBe(true);
     expect(fs.existsSync('dist/index.d.ts')).toBe(true);
   });
 
-  it('creates CJS bundle', function () {
+  it('creates CJS bundle', () => {
     expect(fs.existsSync('cjs/index.cjs')).toBe(true);
     expect(fs.existsSync('cjs/index.d.cts')).toBe(true);
   });
 
-  it('creates UMD bundles', function () {
+  it('creates UMD bundles', () => {
     expect(fs.existsSync('umd/ZSchema.js')).toBe(true);
     expect(fs.existsSync('umd/ZSchema.min.js')).toBe(true);
   });

--- a/test/spec/cli-smoke.node-spec.ts
+++ b/test/spec/cli-smoke.node-spec.ts
@@ -1,8 +1,8 @@
 import child from 'child_process';
 import path from 'path';
 
-describe('CLI smoke', function () {
-  it('runs `bin/z-schema` against sample fixtures and passes', function () {
+describe('CLI smoke', () => {
+  it('runs `bin/z-schema` against sample fixtures and passes', () => {
     const res = child.spawnSync(
       process.execPath,
       ['bin/z-schema', 'test/fixtures/sample-schema.json', 'test/fixtures/sample-valid.json'],
@@ -12,7 +12,7 @@ describe('CLI smoke', function () {
     expect(res.stdout || res.stderr).toMatch(/validation passed/i);
   });
 
-  it('prints the JSON filename in validation output', function () {
+  it('prints the JSON filename in validation output', () => {
     const res = child.spawnSync(
       process.execPath,
       ['bin/z-schema', 'test/fixtures/sample-schema.json', 'test/fixtures/sample-valid.json'],
@@ -23,7 +23,7 @@ describe('CLI smoke', function () {
     expect(res.stdout).not.toMatch(/json #/);
   });
 
-  it('outputs paths relative to the cwd, even for absolute inputs and same-basename files', function () {
+  it('outputs paths relative to the cwd, even for absolute inputs and same-basename files', () => {
     const absoluteValid = path.resolve('test/fixtures/sample-valid.json');
     const nestedValid = 'test/fixtures/nested/sample-valid.json';
     const res = child.spawnSync(

--- a/test/spec/exclude-errors.spec.ts
+++ b/test/spec/exclude-errors.spec.ts
@@ -1,7 +1,7 @@
 import { ZSchema } from '../../src/z-schema.ts';
 
-describe('JSON Validation excludeErrors integration', function () {
-  it('should exclude multiple error codes correctly', function () {
+describe('JSON Validation excludeErrors integration', () => {
+  it('should exclude multiple error codes correctly', () => {
     const validator = ZSchema.create({ version: 'draft-04' });
     const schema = {
       type: 'object',

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -2,12 +2,20 @@ import { describe, expect, it } from 'vitest';
 
 import { ZSchema } from '../../src/z-schema.ts';
 
+const asyncValidator = (input: unknown): Promise<boolean> =>
+  Promise.resolve(typeof input === 'string' && input.length > 3);
+
+const slowValidator = async (): Promise<boolean> => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 50); // 50ms delay
+  });
+  return true;
+};
+
 describe('Format Validators', () => {
   describe('Async Format Validator Registration', () => {
     it('should register an async format validator', () => {
       const validator = ZSchema.create();
-
-      const asyncValidator = async (input: unknown): Promise<boolean> => typeof input === 'string' && input.length > 3;
 
       validator.registerFormat('async-test', asyncValidator);
 
@@ -68,13 +76,6 @@ describe('Format Validators', () => {
   describe('Async Timeout Handling', () => {
     it('should timeout async format validation', async () => {
       const validator = ZSchema.create({ async: true, safe: true, asyncTimeout: 10 }); // 10ms timeout
-
-      const slowValidator = async (): Promise<boolean> => {
-        await new Promise((resolve) => {
-          setTimeout(resolve, 50); // 50ms delay
-        });
-        return true;
-      };
 
       validator.registerFormat('slow-async', slowValidator);
 

--- a/test/spec/instance-custom-formats.spec.ts
+++ b/test/spec/instance-custom-formats.spec.ts
@@ -3,16 +3,12 @@
 
 import { ZSchema } from '../../src/z-schema.ts';
 
-describe('Issue #214: Custom formats are module-scoped', function () {
-  it('should allow custom formats instance scoped', function () {
+describe('Issue #214: Custom formats are module-scoped', () => {
+  it('should allow custom formats instance scoped', () => {
     const validator1 = ZSchema.create({ version: 'draft-04' });
-    validator1.registerFormat('instance1-format', function (str) {
-      return str === 'instance1';
-    });
+    validator1.registerFormat('instance1-format', (str) => str === 'instance1');
     const validator2 = ZSchema.create({ version: 'draft-04' });
-    validator2.registerFormat('instance2-format', function (str) {
-      return str === 'instance2';
-    });
+    validator2.registerFormat('instance2-format', (str) => str === 'instance2');
     // Test validator1
     const schema1 = { type: 'string', format: 'instance1-format' };
     expect(validator1.validateSafe('instance1', schema1).valid).toBe(true);

--- a/test/spec/issue-224.spec.ts
+++ b/test/spec/issue-224.spec.ts
@@ -3,8 +3,8 @@
 
 import { ZSchema } from '../../src/z-schema.ts';
 
-describe('Issue #224: Not getting all schema errors from optional parent object', function () {
-  it('should report all errors for optional object with oneOf including null', function () {
+describe('Issue #224: Not getting all schema errors from optional parent object', () => {
+  it('should report all errors for optional object with oneOf including null', () => {
     const options = { breakOnFirstError: false };
     const validator = ZSchema.create(options);
     const schema = {
@@ -82,7 +82,7 @@ describe('Issue #224: Not getting all schema errors from optional parent object'
     expect(innerPaths).toContain('#/optionalFatherObject/name');
   });
 
-  it('should report all errors for optional object without oneOf', function () {
+  it('should report all errors for optional object without oneOf', () => {
     const options = { breakOnFirstError: false };
     const validator = ZSchema.create(options);
     const schema = {

--- a/test/spec/json-schema-test-suite.browser-spec.ts
+++ b/test/spec/json-schema-test-suite.browser-spec.ts
@@ -3,6 +3,6 @@ import { runTests } from './json-schema-test-suite.common.ts';
 await runTests({
   reader: async <T>(testFilePath: string): Promise<T> => {
     const fileContent = await fetch(testFilePath);
-    return fileContent.json();
+    return await fileContent.json();
   },
 });

--- a/test/spec/json-schema-test-suite.common.ts
+++ b/test/spec/json-schema-test-suite.common.ts
@@ -102,7 +102,7 @@ export async function runTests({ reader }: { reader: <T>(testFilePath: string) =
                 console.warn(`excluded by test description: ${test.description}`);
                 return;
               }
-              it([testSuite.description, test.description].join(' '), function () {
+              it([testSuite.description, test.description].join(' '), () => {
                 const validatorOptions: ZSchemaOptions = { version };
 
                 const isModernFormatSuite = file === 'draft2019-09/format.json' || file === 'draft2020-12/format.json';

--- a/test/spec/json-schema-test-suite.node-spec.ts
+++ b/test/spec/json-schema-test-suite.node-spec.ts
@@ -5,7 +5,7 @@ import { runTests } from './json-schema-test-suite.common.ts';
 
 await runTests({
   reader: <T>(testFilePath: string): Promise<T> => {
-    const fileContent = readFileSync(join(__dirname, '..', 'public', testFilePath), 'utf-8');
+    const fileContent = readFileSync(join(import.meta.dirname, '..', 'public', testFilePath), 'utf-8');
     return JSON.parse(fileContent);
   },
 });

--- a/test/spec/keyword-field.spec.ts
+++ b/test/spec/keyword-field.spec.ts
@@ -1,8 +1,8 @@
 import { ValidateError } from '../../src/errors.ts';
 import { ZSchema } from '../../src/z-schema.ts';
 
-describe('Error objects include `keyword` field', function () {
-  it('JSON validation errors include the keyword that caused the error', function () {
+describe('Error objects include `keyword` field', () => {
+  it('JSON validation errors include the keyword that caused the error', () => {
     const validator = ZSchema.create({ version: 'draft-04' });
     const schema = {
       type: 'object',
@@ -23,7 +23,7 @@ describe('Error objects include `keyword` field', function () {
     expect(missing!.keyword).toBe('required');
   });
 
-  it('Schema validation errors include the keyword that caused the schema validation error', function () {
+  it('Schema validation errors include the keyword that caused the schema validation error', () => {
     const validator = ZSchema.create({ version: 'draft-04' });
     const badSchema = {
       type: 'array',

--- a/test/spec/lib-init-and-usage.spec.ts
+++ b/test/spec/lib-init-and-usage.spec.ts
@@ -3,13 +3,13 @@ import type { ZSchemaAsync, ZSchemaAsyncSafe, ZSchemaSafe } from '../../src/z-sc
 import { ValidateError } from '../../src/index.ts';
 import { ZSchema } from '../../src/z-schema.ts';
 
-describe('Initialization and usage', function () {
-  it('Should not allow to use new', function () {
+describe('Initialization and usage', () => {
+  it('Should not allow to use new', () => {
     // @ts-expect-error: intentionally testing that private constructor throws at runtime
     expect(() => new ZSchema()).toThrow('do not use new ZSchema()');
   });
 
-  it('Should construct validator from factory', async function () {
+  it('Should construct validator from factory', async () => {
     const validator: ZSchema = ZSchema.create({ version: 'none' });
 
     // validate - should return true for valid
@@ -35,7 +35,7 @@ describe('Initialization and usage', function () {
     });
   });
 
-  it('Should create a safe validator from factory', async function () {
+  it('Should create a safe validator from factory', () => {
     const validator: ZSchemaSafe = ZSchema.create({ safe: true, version: 'none' });
     // validate - should return true for valid
     expect(validator.validate(1, { type: 'number' }).valid).toBe(true);
@@ -43,7 +43,7 @@ describe('Initialization and usage', function () {
     expect(validator.validate('not-a-number', { type: 'number' }).valid).toBe(false);
   });
 
-  it('Should create an async validator from factory', async function () {
+  it('Should create an async validator from factory', async () => {
     const validator: ZSchemaAsync = ZSchema.create({ async: true, version: 'none' });
     // validate - should return true for valid
     await expect(validator.validate(1, { type: 'number' })).resolves.toBe(true);
@@ -51,7 +51,7 @@ describe('Initialization and usage', function () {
     await expect(validator.validate('not-a-number', { type: 'number' })).rejects.toThrow(ValidateError);
   });
 
-  it('Should create an async-safe validator from factory', async function () {
+  it('Should create an async-safe validator from factory', async () => {
     const validator: ZSchemaAsyncSafe = ZSchema.create({ async: true, safe: true, version: 'none' });
     // validate - should return true for valid
     await expect(validator.validate(1, { type: 'number' })).resolves.toEqual({ valid: true });

--- a/test/spec/multiple-instances.spec.ts
+++ b/test/spec/multiple-instances.spec.ts
@@ -1,8 +1,8 @@
 import { ValidateError } from '../../src/errors.ts';
 import { ZSchema } from '../../src/z-schema.ts';
 
-describe('Using multiple instances of Z-Schema', function () {
-  it('Should pass all tests', function () {
+describe('Using multiple instances of Z-Schema', () => {
+  it('Should pass all tests', () => {
     const schema = {
       $schema: 'http://json-schema.org/draft-04/schema#',
       type: 'object',

--- a/test/spec/options.breakOnFirstError.spec.ts
+++ b/test/spec/options.breakOnFirstError.spec.ts
@@ -1,7 +1,7 @@
 import { ZSchema } from '../../src/z-schema.ts';
 
 describe('Option breakOnFirstError tests', () => {
-  it('Should break on first error when breakOnFirstError is true', function () {
+  it('Should break on first error when breakOnFirstError is true', () => {
     const validator = ZSchema.create({ breakOnFirstError: true });
     const schema = { type: 'number', maximum: 5, minimum: 15 };
     const invalidData = 10; // violates maximum, would violate minimum too
@@ -11,7 +11,7 @@ describe('Option breakOnFirstError tests', () => {
     expect(result.err!.details!.length).toBe(1); // Only maximum error
   });
 
-  it('Should not break on first error when breakOnFirstError is false', function () {
+  it('Should not break on first error when breakOnFirstError is false', () => {
     const validator = ZSchema.create({ breakOnFirstError: false });
     const schema = { type: 'number', maximum: 5, minimum: 15 };
     const invalidData = 10;

--- a/test/spec/schema-path.spec.ts
+++ b/test/spec/schema-path.spec.ts
@@ -64,8 +64,8 @@ const schema = {
   title: 'Car API',
 };
 
-describe('Using path to schema as a third argument', function () {
-  it('Should pass the test', function () {
+describe('Using path to schema as a third argument', () => {
+  it('Should pass the test', () => {
     const validator = ZSchema.create();
     const cars = [
       {
@@ -79,8 +79,8 @@ describe('Using path to schema as a third argument', function () {
   });
 });
 
-describe('Schema path tracking in validation errors', function () {
-  it('should include schema path for property type validation', function () {
+describe('Schema path tracking in validation errors', () => {
+  it('should include schema path for property type validation', () => {
     const validator = ZSchema.create({ reportPathAsArray: true });
     const testSchema = {
       type: 'object',
@@ -101,7 +101,7 @@ describe('Schema path tracking in validation errors', function () {
     }
   });
 
-  it('should include schema path for array item validation', function () {
+  it('should include schema path for array item validation', () => {
     const validator = ZSchema.create({ reportPathAsArray: true });
     const testSchema = {
       type: 'array',
@@ -119,7 +119,7 @@ describe('Schema path tracking in validation errors', function () {
     }
   });
 
-  it('should include schema path for nested object validation', function () {
+  it('should include schema path for nested object validation', () => {
     const validator = ZSchema.create({ reportPathAsArray: true });
     const testSchema = {
       type: 'object',
@@ -145,7 +145,7 @@ describe('Schema path tracking in validation errors', function () {
     }
   });
 
-  it('should handle root level type validation', function () {
+  it('should handle root level type validation', () => {
     const validator = ZSchema.create({ reportPathAsArray: true });
     const testSchema = { type: 'string' };
     const data = 123;
@@ -160,7 +160,7 @@ describe('Schema path tracking in validation errors', function () {
     }
   });
 
-  it('should include schema path for $ref validation', function () {
+  it('should include schema path for $ref validation', () => {
     const validator = ZSchema.create({ reportPathAsArray: true });
     const testSchema = {
       type: 'object',

--- a/test/spec/thread-safe.spec.ts
+++ b/test/spec/thread-safe.spec.ts
@@ -2,8 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import { ZSchema } from '../../src/z-schema.js';
 
+const asyncStringFormat = async (input: unknown): Promise<boolean> => {
+  const delay = Math.random() * 100;
+  await new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+  return typeof input === 'string';
+};
+
 describe('Thread Safety', () => {
-  it('should not leak errors between concurrent validations', async () => {
+  it('should not leak errors between concurrent validations', () => {
     const validator = ZSchema.create();
     const invalidSchema = { type: 'string' };
     const validSchema = { type: 'string' };
@@ -61,14 +69,6 @@ describe('Thread Safety', () => {
     const validator2 = ZSchema.create({ async: true, safe: true });
 
     // Register async format that waits random 0-100ms then checks if string
-    const asyncStringFormat = async (input: unknown): Promise<boolean> => {
-      const delay = Math.random() * 100;
-      await new Promise((resolve) => {
-        setTimeout(resolve, delay);
-      });
-      return typeof input === 'string';
-    };
-
     validator1.registerFormat('async-string', asyncStringFormat);
     validator2.registerFormat('async-string', asyncStringFormat);
 

--- a/test/spec/z-schema-test-suite.spec.ts
+++ b/test/spec/z-schema-test-suite.spec.ts
@@ -109,7 +109,7 @@ const loadedTestSuiteModules = await Promise.all([
 ]);
 const testSuiteFiles = loadedTestSuiteModules.map((m) => m.default ?? m) as TestSuiteFile[];
 
-describe('ZSchemaTestSuite', function () {
+describe('ZSchemaTestSuite', () => {
   let idx = testSuiteFiles.length;
   while (idx--) {
     if (testSuiteFiles[idx] == null) {
@@ -117,8 +117,8 @@ describe('ZSchemaTestSuite', function () {
     }
   }
 
-  testSuiteFiles.forEach(function (testSuite) {
-    testSuite.tests.forEach(function (test) {
+  testSuiteFiles.forEach((testSuite) => {
+    testSuite.tests.forEach((test) => {
       let { data } = test;
       if (data === undefined) {
         ({ data } = testSuite);
@@ -142,7 +142,7 @@ describe('ZSchemaTestSuite', function () {
         options.version = version;
       }
 
-      it(`${testSuite.description}, ${test.description}`, async function () {
+      it(`${testSuite.description}, ${test.description}`, async () => {
         if (async) {
           const validator = ZSchema.create(options);
           if (setup) {


### PR DESCRIPTION
## Summary

Continues the oxlint TODO-backlog reduction (following PRs #421–#423). Re-enables **8** rules that carry **no performance-regression risk** by removing their TODO overrides (restoring the ultracite preset defaults), and fixes all resulting violations.

### Rules re-enabled
| Rule | Where fixed |
|------|-------------|
| `promise/no-multiple-resolved` | already clean (0 violations) |
| `typescript/no-floating-promises` | already clean (0 violations) |
| `func-names` | cleared by arrow conversions |
| `prefer-arrow-callback` | anonymous callbacks → arrows (src + test) |
| `typescript/return-await` | test |
| `require-await` | test |
| `unicorn/consistent-function-scoping` | test |
| `unicorn/prefer-module` | test (`'use strict'` removal, `__dirname`→`import.meta.dirname`) |

### Notes
- **src changes are limited to 6 behavior-preserving arrow conversions** (`report.ts`, `validation/string.ts`, `z-schema-base.ts`); none use `this`/`arguments`. The bulk of the diff is mechanical test-file arrow conversions.
- One async format validator in `async-validation-example.spec.ts` keeps `async` with a scoped `require-await` disable (it intentionally models an async validator that *rejects* vs. throwing synchronously).
- **`unicorn/no-array-for-each` was deliberately NOT re-enabled**: it governs loop constructs — the category the project keeps off for performance (alongside `typescript/prefer-for-of`). Enabling it globally would push future src hot-path code toward for-of/for rewrites that conflict with the perf policy.

### Verification
- `npm run check` — lint + format clean
- `npm run build:tests` — type-check clean
- `npm test` — 32,389 tests pass, 0 failures