### PR TITLE
chore: enable typescript/prefer-promise-reject-errors

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -41,5 +41,5 @@ Line coverage status: **high**
 | src/z-schema-options.ts       |     92% |         92% |       100% |      70% |
 | src/z-schema-reader.ts        |    100% |        100% |       100% |     100% |
 | src/z-schema-versions.ts      |    100% |        100% |       100% |      75% |
-| src/z-schema.ts               |     76% |         76% |        79% |     100% |
-| **Total**                     | **90%** |     **90%** |    **95%** |  **88%** |
+| src/z-schema.ts               |     76% |         76% |        79% |      83% |
+| **Total**                     | **90%** |     **90%** |    **95%** |  **87%** |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -196,14 +196,6 @@ export default defineConfig({
     // type: maintainability
     // Requires class methods that do not use `this` to be declared as `static`.
     'class-methods-use-this': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 4
-    // complexity: dangerous
-    // The validator intentionally rejects promises with structured validation reports, not Error instances; changing this is an API change.
-    // type: bug-prevention
-    // Requires Promise rejection reasons to be Error objects.
-    'typescript/prefer-promise-reject-errors': 'off',
   },
   overrides: [
     {

--- a/src/z-schema.ts
+++ b/src/z-schema.ts
@@ -161,13 +161,13 @@ export class ZSchema extends ZSchemaBase {
       try {
         this._validate(json, schema, options || {}, (err, valid) => {
           if (err || !valid) {
-            reject(err);
+            reject(err ?? new Error('Validation failed'));
           } else {
             resolve(valid);
           }
         });
       } catch (error) {
-        reject(error);
+        reject(error instanceof Error ? error : new Error(String(error)));
       }
     });
   }
@@ -271,13 +271,13 @@ export class ZSchemaAsync extends ZSchemaBase {
       try {
         this._validate(json, schema, options, (err, valid) => {
           if (err || !valid) {
-            reject(err);
+            reject(err ?? new Error('Validation failed'));
           } else {
             resolve(valid);
           }
         });
       } catch (error) {
-        reject(error);
+        reject(error instanceof Error ? error : new Error(String(error)));
       }
     });
   }

--- a/src/z-schema.ts
+++ b/src/z-schema.ts
@@ -167,7 +167,7 @@ export class ZSchema extends ZSchemaBase {
           }
         });
       } catch (error) {
-        reject(error instanceof Error ? error : new Error(String(error)));
+        reject(error instanceof Error ? error : new Error(String(error), { cause: error }));
       }
     });
   }
@@ -277,7 +277,7 @@ export class ZSchemaAsync extends ZSchemaBase {
           }
         });
       } catch (error) {
-        reject(error instanceof Error ? error : new Error(String(error)));
+        reject(error instanceof Error ? error : new Error(String(error), { cause: error }));
       }
     });
   }


### PR DESCRIPTION
## Summary

Enables the last rule in the [oxlint.config.ts](oxlint.config.ts) TODO backlog. The old override comment claimed the rule had to stay off because the validator "intentionally rejects promises with structured validation reports, **not Error instances**; changing this is an API change."

**That rationale was incorrect.** `ValidateError extends Error` ([errors.ts](src/errors.ts)) — it's a proper `Error` subclass, and tests already assert `.rejects.toThrow(ValidateError)` while docs document a `ValidateError`. So this is **not** an API change.

The rule flagged 4 sites in `src/z-schema.ts` purely on a **type-level** gap (not runtime behavior):
- callback rejects `err` typed `ValidateError | undefined`
- catch rejects `error` typed `unknown`

At runtime `err` is always a `ValidateError` when validation fails, and the catch only ever sees thrown `Error`s.

## Changes
- **oxlint.config.ts** — remove the override (restores preset `error`).
- **src/z-schema.ts** (both `ZSchema.validateAsync` and `ZSchemaAsync.validate`, 4 lines):
  - `reject(err)` → `reject(err ?? new Error('Validation failed'))`
  - `reject(error)` → `reject(error instanceof Error ? error : new Error(String(error)))`

Behavior-preserving: reachable paths still reject with the real `ValidateError`; the fallbacks only cover unreachable type-level cases and harden against rejecting `undefined`/non-`Error`. No new imports (uses global `Error`; `ValidateError` stays a type-only import). No performance impact (async reject path, not a validation hot loop).

## Verification
- `npm run check` — lint + format clean
- `npm run build:tests` — type-check clean
- `npm test` — 32,389 tests pass; rejection-contract tests (`.rejects.toThrow(ValidateError)`, `.details`) confirmed green on the node project