### PR TITLE
chore: enable no-use-before-define oxlint rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     'no-inline-comments': 'off',
     'no-param-reassign': 'off',
     'no-plusplus': 'off',
+    'no-use-before-define': ['error', { functions: false, classes: false, variables: true }],
     'no-unused-vars': [
       'error',
       { args: 'after-used', argsIgnorePattern: '^_', caughtErrors: 'all', caughtErrorsIgnorePattern: '^_' },
@@ -107,14 +108,6 @@ export default defineConfig({
     // type: best-practice
     // Prefers `async`/`await` over callback-based APIs when a promise-based alternative is available.
     'promise/prefer-await-to-callbacks': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 26
-    // complexity: moderate
-    // Identifiers are referenced before their declaration; hoisting or reordering declarations is required per site.
-    // type: bug-prevention
-    // Disallows references to variables, functions, or classes before they are defined in the source.
-    'no-use-before-define': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 23

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -47,6 +47,69 @@ interface Id {
   absoluteUri?: string;
 }
 
+const resolveReference = (base: string | undefined, ref: string) => {
+  if (isAbsoluteUri(ref)) {
+    return ref;
+  }
+
+  const baseStr = base ?? '';
+
+  if (ref.startsWith('#')) {
+    const hashIndex = baseStr.indexOf('#');
+    const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
+    return baseNoFrag + ref;
+  }
+
+  if (!baseStr) {
+    return ref;
+  }
+
+  const hashIndex = baseStr.indexOf('#');
+  const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
+
+  if (isAbsoluteUri(baseNoFrag)) {
+    try {
+      return new URL(ref, baseNoFrag).toString();
+    } catch {
+      // fall back to manual resolution below
+    }
+  }
+
+  let baseDir = baseNoFrag;
+  if (!baseDir.endsWith('/')) {
+    const lastSlash = baseDir.lastIndexOf('/');
+    baseDir = lastSlash === -1 ? '' : baseDir.slice(0, lastSlash + 1);
+  }
+  return baseDir + ref;
+};
+
+const isSimpleIdentifier = (id: string) =>
+  !id.startsWith('#') && !id.includes('/') && !id.includes('.') && !id.includes('#');
+
+const resolveIdScope = (base: string | undefined, id: string) => {
+  if (isAbsoluteUri(id)) {
+    return id;
+  }
+
+  const baseStr = base ?? '';
+
+  // Treat simple identifiers (no '/', '.', or '#') as same-document fragment ids
+  if (isSimpleIdentifier(id)) {
+    const hashIndex = baseStr.indexOf('#');
+    const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
+    return `${baseNoFrag}#${id}`;
+  }
+
+  return resolveReference(base, id);
+};
+
+const resolveSchemaScopeId = (base: string | undefined, schema: JsonSchemaInternal, id: string) => {
+  if (typeof schema.$id === 'string') {
+    return resolveReference(base, id);
+  }
+  return resolveIdScope(base, id);
+};
+
 export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECURSION_DEPTH) => {
   const ids: Id[] = [];
   function walk(node: any, scope: Id[], _depth = 0) {
@@ -223,69 +286,6 @@ export const collectReferences = (
   }
 
   return results;
-};
-
-const resolveReference = (base: string | undefined, ref: string) => {
-  if (isAbsoluteUri(ref)) {
-    return ref;
-  }
-
-  const baseStr = base ?? '';
-
-  if (ref.startsWith('#')) {
-    const hashIndex = baseStr.indexOf('#');
-    const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
-    return baseNoFrag + ref;
-  }
-
-  if (!baseStr) {
-    return ref;
-  }
-
-  const hashIndex = baseStr.indexOf('#');
-  const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
-
-  if (isAbsoluteUri(baseNoFrag)) {
-    try {
-      return new URL(ref, baseNoFrag).toString();
-    } catch {
-      // fall back to manual resolution below
-    }
-  }
-
-  let baseDir = baseNoFrag;
-  if (!baseDir.endsWith('/')) {
-    const lastSlash = baseDir.lastIndexOf('/');
-    baseDir = lastSlash === -1 ? '' : baseDir.slice(0, lastSlash + 1);
-  }
-  return baseDir + ref;
-};
-
-const isSimpleIdentifier = (id: string) =>
-  !id.startsWith('#') && !id.includes('/') && !id.includes('.') && !id.includes('#');
-
-const resolveIdScope = (base: string | undefined, id: string) => {
-  if (isAbsoluteUri(id)) {
-    return id;
-  }
-
-  const baseStr = base ?? '';
-
-  // Treat simple identifiers (no '/', '.', or '#') as same-document fragment ids
-  if (isSimpleIdentifier(id)) {
-    const hashIndex = baseStr.indexOf('#');
-    const baseNoFrag = hashIndex === -1 ? baseStr : baseStr.slice(0, hashIndex);
-    return `${baseNoFrag}#${id}`;
-  }
-
-  return resolveReference(base, id);
-};
-
-const resolveSchemaScopeId = (base: string | undefined, schema: JsonSchemaInternal, id: string) => {
-  if (typeof schema.$id === 'string') {
-    return resolveReference(base, id);
-  }
-  return resolveIdScope(base, id);
 };
 
 export class SchemaCompiler {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -6,6 +6,8 @@ interface AreEqualOptions {
   maxDepth?: number;
 }
 
+export const sortedKeys = (obj: Record<string, unknown>): string[] => Object.keys(obj).sort();
+
 export const areEqual = (json1: unknown, json2: unknown, options?: AreEqualOptions, _depth = 0): boolean => {
   const caseInsensitiveComparison = options?.caseInsensitiveComparison || false;
   const maxDepth = options?.maxDepth ?? DEFAULT_MAX_RECURSION_DEPTH;
@@ -77,8 +79,6 @@ export const areEqual = (json1: unknown, json2: unknown, options?: AreEqualOptio
 
 export const decodeJSONPointer = (str: string) =>
   decodeURIComponent(str).replaceAll(/~[0-1]/g, (x) => (x === '~1' ? '/' : '~'));
-
-export const sortedKeys = (obj: Record<string, unknown>): string[] => Object.keys(obj).sort();
 
 export const get = (obj: any, path: string | Array<string | number>): any => {
   if (typeof path === 'string') {


### PR DESCRIPTION
## Summary

Promotes 
o-use-before-define out of the oxlint TODO backlog and enables it as an error, continuing the incremental re-enable effort.

Configured as:

\\\	s
'no-use-before-define': ['error', { functions: false, classes: false, variables: true }]
\\\

Rationale (audit of the 26 prior violations, all runtime-safe today):

- **Function declarations** (\alidate\, \propertiesValidator\) are hoisted — \unctions: false\ allows them; reordering would be a large, noisy diff in core/hot-path files for zero runtime benefit.
- **Factory-pattern classes** (\ZSchemaSafe\/\ZSchemaAsync\/\ZSchemaAsyncSafe\ used in \ZSchema.create()\) — \classes: false\ allows the idiomatic factory-at-top layout.
- **\const\ arrows** — the genuine variable-TDZ category, now enforced (\ariables: true\).

## Changes

- **oxlint.config.ts** — remove the TODO entry, add the rule to the intentional-rules block.
- **src/utils/json.ts** — move \sortedKeys\ above \reEqual\ (its only caller). Pure relocation.
- **src/schema-compiler.ts** — move the resolver helper block (\esolveReference\, \isSimpleIdentifier\, \esolveIdScope\, \esolveSchemaScopeId\) above \collectIds\. Pure relocation (symmetric 50-line move, no logic change).

## Test plan

- [x] \
px oxlint --type-aware\ — clean, zero \
o-use-before-define\ errors
- [x] \
pm run build\ + \
pm run build:tests\ — pass
- [x] \
pm test\ — 102 files / 32389 tests pass