### PR TITLE
chore: reclassify promise/prefer-await-to-callbacks as intentional-off

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
     ],
     'no-warning-comments': 'off',
     'promise/avoid-new': 'off',
+    // Kept off intentionally (not a TODO): the flagged callbacks are public-API
+    // contract — the exported `ValidateCallback` `validate`/`_validate` overload,
+    // `Report.processAsyncTasks`, and the user-registered `(str, callback)` async
+    // format-validator signature. Enabling would force a breaking API change.
+    'promise/prefer-await-to-callbacks': 'off',
     'require-unicode-regexp': 'off',
     'sort-keys': 'off',
     'typescript/array-type': ['error', { default: 'array-simple' }],
@@ -100,14 +105,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows calling values typed as `any`, which bypasses TypeScript's call-signature checking.
     'typescript/no-unsafe-call': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 27
-    // complexity: moderate
-    // Callbacks are passed where `async`/`await` equivalents exist; refactoring requires verifying async compatibility of each call site.
-    // type: best-practice
-    // Prefers `async`/`await` over callback-based APIs when a promise-based alternative is available.
-    'promise/prefer-await-to-callbacks': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 23


### PR DESCRIPTION
## What

Moves `promise/prefer-await-to-callbacks` out of the TODO backlog block in `oxlint.config.ts` into the intentional-off set (with a rationale comment), rather than enabling it.

## Why

Its 18 `src/` violations are all **genuine public-API callbacks**, not trivially convertible internal ones:

- the exported `ValidateCallback` `validate`/`_validate` overload,
- `Report.processAsyncTasks`,
- the user-registered `(str, callback)` async format-validator contract (`registerFormat`).

Enabling the rule would force a **breaking change to the public async API** (dropping/reshaping the callback overload and the async task queue). That is out of scope for a lint-cleanup chore, so it is reclassified as intentional-off with a comment explaining the contract.

Mirrors the prior reclassification PRs #426 / #428 / #429.

## Verification

- `npx oxlint --type-aware` → clean (exit 0).
- Config-only change; no source touched, so runtime behavior is unchanged by construction.