### PR TITLE
refactor: enable oxc/no-this-in-exported-function

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -31,9 +31,8 @@ export default defineConfig({
     'no-warning-comments': 'off',
     'promise/avoid-new': 'off',
     // Kept off intentionally (not a TODO): the flagged callbacks are public-API
-    // contract — the exported `ValidateCallback` `validate`/`_validate` overload,
-    // `Report.processAsyncTasks`, and the user-registered `(str, callback)` async
-    // format-validator signature. Enabling would force a breaking API change.
+    // contract — the exported `ValidateCallback` `validate`/`_validate` overload
+    // and `Report.processAsyncTasks`. Enabling would force a breaking API change.
     'promise/prefer-await-to-callbacks': 'off',
     'require-unicode-regexp': 'off',
     'sort-keys': 'off',
@@ -89,14 +88,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows accessing properties on values typed as `any`, which bypasses TypeScript's type checking.
     'typescript/no-unsafe-member-access': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 81
-    // complexity: moderate
-    // `this` is used inside functions that are exported; restructuring requires converting them to methods or passing context explicitly.
-    // type: bug-prevention
-    // Disallows `this` inside exported standalone functions where the `this` context is unpredictable.
-    'oxc/no-this-in-exported-function': 'off',
 
     // TODO: evaluate this rule in the future
     // occurrences in codebase: 32

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -85,14 +85,14 @@ interface CollectEvaluatedPropertiesArgs {
 
 type CollectEvaluatedArgs = CollectEvaluatedItemsArgs | CollectEvaluatedPropertiesArgs;
 
-function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<number | string> | 'all' {
+function collectEvaluated(ctx: ZSchemaBase, args: CollectEvaluatedArgs): Set<number | string> | 'all' {
   const { report, currentSchema, json, mode, depth } = args;
 
   if (!currentSchema || typeof currentSchema === 'boolean') {
     return new Set();
   }
 
-  if (depth > (this.options.maxRecursionDepth ?? 100)) {
+  if (depth > (ctx.options.maxRecursionDepth ?? 100)) {
     report.addError('COLLECT_EVALUATED_DEPTH_EXCEEDED', [depth]);
     return new Set();
   }
@@ -111,7 +111,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 
   const recurse = (subSchema: JsonSchemaInternal | boolean | undefined): Set<number | string> | 'all' => {
     if (mode === 'items') {
-      return collectEvaluated.call(this, {
+      return collectEvaluated(ctx, {
         report,
         currentSchema: subSchema,
         json,
@@ -120,7 +120,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
         depth: depth + 1,
       });
     }
-    return collectEvaluated.call(this, {
+    return collectEvaluated(ctx, {
       report,
       currentSchema: subSchema,
       json,
@@ -169,7 +169,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
         let passed = getCachedValidationResult(report, currentSchema.contains, jsonArr[i]);
         if (passed === undefined) {
           const subReport = new Report(report);
-          validate.call(this, subReport, currentSchema.contains as JsonSchemaInternal | boolean, jsonArr[i]);
+          validate(ctx, subReport, currentSchema.contains as JsonSchemaInternal | boolean, jsonArr[i]);
           passed = subReport.errors.length === 0;
         }
         if (passed) {
@@ -277,7 +277,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
       let passed = getCachedValidationResult(report, subSchema, json);
       if (passed === undefined) {
         const subReport = new Report(report);
-        validate.call(this, subReport, subSchema as JsonSchemaInternal | boolean, json);
+        validate(ctx, subReport, subSchema as JsonSchemaInternal | boolean, json);
         passed = subReport.errors.length === 0;
       }
       if (passed && merge(recurse(subSchema as JsonSchemaInternal | boolean))) {
@@ -293,7 +293,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
       let passed = getCachedValidationResult(report, subSchema, json);
       if (passed === undefined) {
         const subReport = new Report(report);
-        validate.call(this, subReport, subSchema as JsonSchemaInternal | boolean, json);
+        validate(ctx, subReport, subSchema as JsonSchemaInternal | boolean, json);
         passed = subReport.errors.length === 0;
       }
       if (passed && merge(recurse(subSchema as JsonSchemaInternal | boolean))) {
@@ -307,7 +307,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
     let condPassed = getCachedValidationResult(report, currentSchema.if, json);
     if (condPassed === undefined) {
       const condReport = new Report(report);
-      validate.call(this, condReport, currentSchema.if as JsonSchemaInternal | boolean, json);
+      validate(ctx, condReport, currentSchema.if as JsonSchemaInternal | boolean, json);
       condPassed = condReport.errors.length === 0;
     }
     if (condPassed) {
@@ -350,7 +350,7 @@ function collectEvaluated(this: ZSchemaBase, args: CollectEvaluatedArgs): Set<nu
 // unevaluatedItems
 // ---------------------------------------------------------------------------
 
-function unevaluatedItemsValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+function unevaluatedItemsValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   if (!Array.isArray(json)) {
     return;
   }
@@ -369,7 +369,7 @@ function unevaluatedItemsValidator(this: ZSchemaBase, report: Report, schema: Js
     return;
   }
 
-  const evaluatedItems = collectEvaluated.call(this, {
+  const evaluatedItems = collectEvaluated(ctx, {
     report,
     currentSchema: schema,
     json,
@@ -400,7 +400,7 @@ function unevaluatedItemsValidator(this: ZSchemaBase, report: Report, schema: Js
     for (let i = 0; i < unevaluatedIndices.length; i++) {
       const idx = unevaluatedIndices[i];
       const subReport = new Report(report);
-      validate.call(this, subReport, unevalSchema as JsonSchemaInternal, json[idx]);
+      validate(ctx, subReport, unevalSchema as JsonSchemaInternal, json[idx]);
       if (subReport.errors.length > 0) {
         report.addError('ARRAY_UNEVALUATED_ITEMS', undefined, undefined, schema, 'unevaluatedItems');
         break;
@@ -413,7 +413,7 @@ function unevaluatedItemsValidator(this: ZSchemaBase, report: Report, schema: Js
 // unevaluatedProperties
 // ---------------------------------------------------------------------------
 
-function unevaluatedPropertiesValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+function unevaluatedPropertiesValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   if (!isObject(json)) {
     return;
   }
@@ -434,7 +434,7 @@ function unevaluatedPropertiesValidator(this: ZSchemaBase, report: Report, schem
     return;
   }
 
-  const evaluatedProperties = collectEvaluated.call(this, {
+  const evaluatedProperties = collectEvaluated(ctx, {
     report,
     currentSchema: schema,
     json,
@@ -471,7 +471,7 @@ function unevaluatedPropertiesValidator(this: ZSchemaBase, report: Report, schem
     for (let i = 0; i < unevaluatedKeys.length; i++) {
       const key = unevaluatedKeys[i];
       const subReport = new Report(report);
-      validate.call(this, subReport, unevalSchema as JsonSchemaInternal, (json as Record<string, unknown>)[key]);
+      validate(ctx, subReport, unevalSchema as JsonSchemaInternal, (json as Record<string, unknown>)[key]);
       if (subReport.errors.length > 0) {
         report.addError('OBJECT_UNEVALUATED_PROPERTIES', [key], undefined, schema, 'unevaluatedProperties');
       }
@@ -577,25 +577,25 @@ export const JsonValidators: Record<keyof JsonSchemaAll, JsonValidatorFn> = {
 // recurseArray
 // ---------------------------------------------------------------------------
 
-function recurseArray(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown[]) {
+function recurseArray(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown[]) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.2
 
   const schemaUri = typeof schema.$schema === 'string' ? schema.$schema : undefined;
   const isDraft202012Schema =
     schemaUri === 'https://json-schema.org/draft/2020-12/schema' ||
-    (!schemaUri && this.options.version === 'draft2020-12');
+    (!schemaUri && ctx.options.version === 'draft2020-12');
   const prefixItems = isDraft202012Schema && Array.isArray(schema.prefixItems) ? schema.prefixItems : undefined;
 
   if (prefixItems) {
     for (let idx = 0; idx < json.length; idx++) {
       if (idx < prefixItems.length) {
         report.path.push(idx);
-        validate.call(this, report, prefixItems[idx], json[idx]);
+        validate(ctx, report, prefixItems[idx], json[idx]);
         report.path.pop();
       } else if (schema.items !== undefined && !Array.isArray(schema.items)) {
         report.path.push(idx);
         report.schemaPath.push('items');
-        validate.call(this, report, schema.items, json[idx]);
+        validate(ctx, report, schema.items, json[idx]);
         report.schemaPath.pop();
         report.path.pop();
       }
@@ -612,12 +612,12 @@ function recurseArray(this: ZSchemaBase, report: Report, schema: JsonSchemaInter
       // equal to doesn't make sense here
       if (idx < schema.items.length) {
         report.path.push(idx);
-        validate.call(this, report, schema.items[idx], json[idx]);
+        validate(ctx, report, schema.items[idx], json[idx]);
         report.path.pop();
       } else if (typeof schema.additionalItems === 'object') {
         // might be boolean, so check that it's an object
         report.path.push(idx);
-        validate.call(this, report, schema.additionalItems, json[idx]);
+        validate(ctx, report, schema.additionalItems, json[idx]);
         report.path.pop();
       }
     }
@@ -628,7 +628,7 @@ function recurseArray(this: ZSchemaBase, report: Report, schema: JsonSchemaInter
       report.path.push(idx);
       // Track schema path for array items validation
       report.schemaPath.push('items');
-      validate.call(this, report, schema.items, json[idx]);
+      validate(ctx, report, schema.items, json[idx]);
       report.schemaPath.pop();
       report.path.pop();
     }
@@ -639,7 +639,7 @@ function recurseArray(this: ZSchemaBase, report: Report, schema: JsonSchemaInter
 // recurseObject
 // ---------------------------------------------------------------------------
 
-function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Record<any, any>) {
+function recurseObject(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Record<any, any>) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3
 
   // If "additionalProperties" is absent, it is considered present with an empty schema as a value.
@@ -709,7 +709,7 @@ function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInte
         // This is additionalProperties or patternProperties
         report.schemaPath.push('additionalProperties');
       }
-      validate.call(this, report, schema_s, propertyValue);
+      validate(ctx, report, schema_s, propertyValue);
       report.path.pop();
       report.schemaPath.pop();
       if (isProp) {
@@ -724,7 +724,7 @@ function recurseObject(this: ZSchemaBase, report: Report, schema: JsonSchemaInte
 // ---------------------------------------------------------------------------
 
 export function validate(
-  this: ZSchemaBase,
+  ctx: ZSchemaBase,
   report: Report,
   schema: boolean | JsonSchemaInternal,
   json: unknown
@@ -778,11 +778,11 @@ export function validate(
   // follow schema.$ref keys
   if (schema.$ref !== undefined) {
     const applySiblingKeywordsWithRef =
-      this.options.version === 'draft2019-09' || this.options.version === 'draft2020-12';
+      ctx.options.version === 'draft2019-09' || ctx.options.version === 'draft2020-12';
 
     if (applySiblingKeywordsWithRef) {
       if (schema.__$refResolved) {
-        validate.call(this, report, schema.__$refResolved as JsonSchemaInternal, json);
+        validate(ctx, report, schema.__$refResolved as JsonSchemaInternal, json);
       } else {
         report.addError('REF_UNRESOLVED', [schema.$ref], undefined, schema);
       }
@@ -816,13 +816,13 @@ export function validate(
   // follow schema.$recursiveRef keys
   if (schema.$recursiveRef !== undefined) {
     const applySiblingKeywordsWithRecursiveRef =
-      this.options.version === 'draft2019-09' || this.options.version === 'draft2020-12';
+      ctx.options.version === 'draft2019-09' || ctx.options.version === 'draft2020-12';
 
     if (applySiblingKeywordsWithRecursiveRef) {
       const recursiveRefTarget = resolveRecursiveRef(schema, recursiveAnchorStack);
 
       if (recursiveRefTarget) {
-        validate.call(this, report, recursiveRefTarget, json);
+        validate(ctx, report, recursiveRefTarget, json);
       } else {
         report.addError('REF_UNRESOLVED', [schema.$recursiveRef], undefined, schema);
       }
@@ -835,7 +835,7 @@ export function validate(
 
   // follow schema.$dynamicRef keys
   if (schema.$dynamicRef !== undefined) {
-    const applySiblingKeywordsWithDynamicRef = this.options.version === 'draft2020-12';
+    const applySiblingKeywordsWithDynamicRef = ctx.options.version === 'draft2020-12';
 
     if (applySiblingKeywordsWithDynamicRef) {
       const dynamicRefTarget = resolveDynamicRef(schema, dynamicScopeStack);
@@ -843,7 +843,7 @@ export function validate(
       if (dynamicRefTarget === undefined) {
         report.addError('REF_UNRESOLVED', [schema.$dynamicRef], undefined, schema);
       } else {
-        validate.call(this, report, dynamicRefTarget, json);
+        validate(ctx, report, dynamicRefTarget, json);
       }
       const dynamicRefIdx = keys.indexOf('$dynamicRef');
       if (dynamicRefIdx !== -1) {
@@ -852,7 +852,7 @@ export function validate(
     }
   }
 
-  const validationVocabularyEnabled = isValidationVocabularyEnabled(schema, report, this.options.version);
+  const validationVocabularyEnabled = isValidationVocabularyEnabled(schema, report, ctx.options.version);
   if (!validationVocabularyEnabled) {
     let wi = 0;
     for (let ri = 0; ri < keys.length; ri++) {
@@ -867,9 +867,9 @@ export function validate(
   if (validationVocabularyEnabled && schema.type) {
     keys.splice(keys.indexOf('type'), 1);
     report.schemaPath.push('type');
-    JsonValidators.type.call(this, report, schema, json);
+    JsonValidators.type(ctx, report, schema, json);
     report.schemaPath.pop();
-    if (report.errors.length && this.options.breakOnFirstError) {
+    if (report.errors.length && ctx.options.breakOnFirstError) {
       if (pushedRecursiveAnchor) {
         recursiveAnchorStack.pop();
       }
@@ -892,37 +892,37 @@ export function validate(
     }
     const validator = JsonValidators[key];
     if (validator) {
-      validator.call(this, report, schema, json);
-      if (report.errors.length && this.options.breakOnFirstError) {
+      validator(ctx, report, schema, json);
+      if (report.errors.length && ctx.options.breakOnFirstError) {
         break;
       }
     }
   }
 
   // Run unevaluated* validators after all others have cached their combinator results
-  if (deferredUnevaluatedKeys.length > 0 && !(report.errors.length > 0 && this.options.breakOnFirstError)) {
+  if (deferredUnevaluatedKeys.length > 0 && !(report.errors.length > 0 && ctx.options.breakOnFirstError)) {
     for (let i = 0; i < deferredUnevaluatedKeys.length; i++) {
       const key = deferredUnevaluatedKeys[i];
       const validator = JsonValidators[key];
       if (validator) {
-        validator.call(this, report, schema, json);
-        if (report.errors.length && this.options.breakOnFirstError) {
+        validator(ctx, report, schema, json);
+        if (report.errors.length && ctx.options.breakOnFirstError) {
           break;
         }
       }
     }
   }
 
-  if (report.errors.length === 0 || this.options.breakOnFirstError === false) {
+  if (report.errors.length === 0 || ctx.options.breakOnFirstError === false) {
     if (Array.isArray(json)) {
-      recurseArray.call(this, report, schema, json);
+      recurseArray(ctx, report, schema, json);
     } else if (isObject(json)) {
-      recurseObject.call(this, report, schema, json);
+      recurseObject(ctx, report, schema, json);
     }
   }
 
-  if (typeof this.options.customValidator === 'function') {
-    this.options.customValidator.call(this, report, schema, json);
+  if (typeof ctx.options.customValidator === 'function') {
+    ctx.options.customValidator.call(ctx, report, schema, json);
   }
 
   if (pushedRecursiveAnchor) {

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -731,7 +731,7 @@ export class SchemaValidator {
     if (hasParentSchema) {
       if (schema.__$schemaResolved && schema.__$schemaResolved !== schema) {
         const subReport = new Report(report);
-        const valid = validate.call(this.validator, subReport, schema.__$schemaResolved, schema);
+        const valid = validate(this.validator, subReport, schema.__$schemaResolved, schema);
         if (!valid) {
           report.addError('PARENT_SCHEMA_VALIDATION_FAILED', undefined, subReport, schema, '$schema');
         }
@@ -799,7 +799,7 @@ export class SchemaValidator {
         report.path.push('enum');
         for (let idx = 0; idx < schema.enum.length; idx++) {
           report.path.push(idx);
-          validate.call(this.validator, report, tmpSchema, schema.enum[idx]);
+          validate(this.validator, report, tmpSchema, schema.enum[idx]);
           report.path.pop();
         }
         report.path.pop();
@@ -807,7 +807,7 @@ export class SchemaValidator {
 
       if (schema.default) {
         report.path.push('default');
-        validate.call(this.validator, report, schema, schema.default);
+        validate(this.validator, report, schema, schema.default);
         report.path.pop();
       }
     }

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -9,9 +9,9 @@ import { cacheValidationResult, deferOrRunSync, shouldSkipValidate } from './sha
 // additionalItems
 // ---------------------------------------------------------------------------
 
-export function additionalItemsValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function additionalItemsValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.1.2
-  if (shouldSkipValidate(this.validateOptions, ['ARRAY_ADDITIONAL_ITEMS'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['ARRAY_ADDITIONAL_ITEMS'])) {
     return;
   }
   if (!Array.isArray(json)) {
@@ -45,9 +45,9 @@ export function prefixItemsValidator() {
 // maxItems
 // ---------------------------------------------------------------------------
 
-export function maxItemsValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function maxItemsValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.2.2
-  if (shouldSkipValidate(this.validateOptions, ['ARRAY_LENGTH_LONG'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['ARRAY_LENGTH_LONG'])) {
     return;
   }
   if (!Array.isArray(json)) {
@@ -62,9 +62,9 @@ export function maxItemsValidator(this: ZSchemaBase, report: Report, schema: Jso
 // minItems
 // ---------------------------------------------------------------------------
 
-export function minItemsValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function minItemsValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.3.2
-  if (shouldSkipValidate(this.validateOptions, ['ARRAY_LENGTH_SHORT'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['ARRAY_LENGTH_SHORT'])) {
     return;
   }
   if (!Array.isArray(json)) {
@@ -79,9 +79,9 @@ export function minItemsValidator(this: ZSchemaBase, report: Report, schema: Jso
 // uniqueItems
 // ---------------------------------------------------------------------------
 
-export function uniqueItemsValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function uniqueItemsValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.3.4.2
-  if (shouldSkipValidate(this.validateOptions, ['ARRAY_UNIQUE'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['ARRAY_UNIQUE'])) {
     return;
   }
   if (!Array.isArray(json)) {
@@ -89,7 +89,7 @@ export function uniqueItemsValidator(this: ZSchemaBase, report: Report, schema: 
   }
   if (schema.uniqueItems === true) {
     const matches: any[] = [];
-    if (!isUniqueArray(json, matches, this.options.maxRecursionDepth)) {
+    if (!isUniqueArray(json, matches, ctx.options.maxRecursionDepth)) {
       report.addError('ARRAY_UNIQUE', matches, undefined, schema, 'uniqueItems');
     }
   }
@@ -99,8 +99,8 @@ export function uniqueItemsValidator(this: ZSchemaBase, report: Report, schema: 
 // contains
 // ---------------------------------------------------------------------------
 
-export function containsValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
-  if (shouldSkipValidate(this.validateOptions, ['CONTAINS'])) {
+export function containsValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+  if (shouldSkipValidate(ctx.validateOptions, ['CONTAINS'])) {
     return;
   }
 
@@ -118,7 +118,7 @@ export function containsValidator(this: ZSchemaBase, report: Report, schema: Jso
   for (let idx = 0; idx < json.length; idx++) {
     const subReport = new Report_(report);
     subReports.push(subReport);
-    this._jsonValidate(subReport, containsSchema as any, json[idx]);
+    ctx._jsonValidate(subReport, containsSchema as any, json[idx]);
     cacheValidationResult(report, containsSchema, json[idx], subReport.errors.length === 0);
   }
 
@@ -130,7 +130,7 @@ export function containsValidator(this: ZSchemaBase, report: Report, schema: Jso
       }
     }
 
-    const supportsContainsBounds = this.options.version === 'draft2019-09' || this.options.version === 'draft2020-12';
+    const supportsContainsBounds = ctx.options.version === 'draft2019-09' || ctx.options.version === 'draft2020-12';
     const minContains: number =
       supportsContainsBounds && typeof schema.minContains === 'number' ? (schema.minContains ?? 1) : 1;
     const maxContains =

--- a/src/validation/combinators.ts
+++ b/src/validation/combinators.ts
@@ -8,11 +8,11 @@ import { cacheValidationResult, deferOrRunSync } from './shared.js';
 // allOf
 // ---------------------------------------------------------------------------
 
-export function allOfValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function allOfValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.3.2
   for (let i = 0; i < schema.allOf!.length; i++) {
-    const validateResult = this._jsonValidate(report, schema.allOf![i], json);
-    if (this.options.breakOnFirstError && !validateResult) {
+    const validateResult = ctx._jsonValidate(report, schema.allOf![i], json);
+    if (ctx.options.breakOnFirstError && !validateResult) {
       break;
     }
   }
@@ -22,14 +22,14 @@ export function allOfValidator(this: ZSchemaBase, report: Report, schema: JsonSc
 // anyOf
 // ---------------------------------------------------------------------------
 
-export function anyOfValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function anyOfValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.4.2
   const subReports: Report[] = [];
 
   for (let i = 0; i < schema.anyOf!.length; i++) {
     const subReport = new Report(report);
     subReports.push(subReport);
-    this._jsonValidate(subReport, schema.anyOf![i], json);
+    ctx._jsonValidate(subReport, schema.anyOf![i], json);
     cacheValidationResult(report, schema.anyOf![i], json, subReport.errors.length === 0);
   }
 
@@ -53,14 +53,14 @@ export function anyOfValidator(this: ZSchemaBase, report: Report, schema: JsonSc
 // oneOf
 // ---------------------------------------------------------------------------
 
-export function oneOfValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function oneOfValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.5.2
   const subReports: Report[] = [];
 
   for (let i = 0; i < schema.oneOf!.length; i++) {
     const subReport = new Report(report);
     subReports.push(subReport);
-    this._jsonValidate(subReport, schema.oneOf![i], json);
+    ctx._jsonValidate(subReport, schema.oneOf![i], json);
     cacheValidationResult(report, schema.oneOf![i], json, subReport.errors.length === 0);
   }
 
@@ -85,10 +85,10 @@ export function oneOfValidator(this: ZSchemaBase, report: Report, schema: JsonSc
 // not
 // ---------------------------------------------------------------------------
 
-export function notValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function notValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.6.2
   const subReport = new Report(report);
-  if (this._jsonValidate(subReport, schema.not!, json)) {
+  if (ctx._jsonValidate(subReport, schema.not!, json)) {
     report.addError('NOT_PASSED', undefined, undefined, schema, 'not');
   }
 }
@@ -97,8 +97,8 @@ export function notValidator(this: ZSchemaBase, report: Report, schema: JsonSche
 // if / then / else
 // ---------------------------------------------------------------------------
 
-export function ifValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
-  if (this.options.version === 'draft-04' || this.options.version === 'draft-06') {
+export function ifValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+  if (ctx.options.version === 'draft-04' || ctx.options.version === 'draft-06') {
     return;
   }
 
@@ -111,7 +111,7 @@ export function ifValidator(this: ZSchemaBase, report: Report, schema: JsonSchem
   }
 
   const conditionReport = new Report(report);
-  this._jsonValidate(conditionReport, conditionSchema as any, json);
+  ctx._jsonValidate(conditionReport, conditionSchema as any, json);
   cacheValidationResult(report, conditionSchema, json, conditionReport.errors.length === 0);
 
   const branchSchema = conditionReport.errors.length === 0 ? thenSchema : elseSchema;
@@ -119,7 +119,7 @@ export function ifValidator(this: ZSchemaBase, report: Report, schema: JsonSchem
     return;
   }
 
-  this._jsonValidate(report, branchSchema as any, json);
+  ctx._jsonValidate(report, branchSchema as any, json);
 }
 
 export function thenValidator() {

--- a/src/validation/numeric.ts
+++ b/src/validation/numeric.ts
@@ -8,9 +8,9 @@ import { shouldSkipValidate } from './shared.js';
 // multipleOf
 // ---------------------------------------------------------------------------
 
-export function multipleOfValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function multipleOfValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.1.2
-  if (shouldSkipValidate(this.validateOptions, ['MULTIPLE_OF'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['MULTIPLE_OF'])) {
     return;
   }
   if (typeof json !== 'number') {
@@ -27,9 +27,9 @@ export function multipleOfValidator(this: ZSchemaBase, report: Report, schema: J
 // maximum
 // ---------------------------------------------------------------------------
 
-export function maximumValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function maximumValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.2.2
-  if (shouldSkipValidate(this.validateOptions, ['MAXIMUM', 'MAXIMUM_EXCLUSIVE'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['MAXIMUM', 'MAXIMUM_EXCLUSIVE'])) {
     return;
   }
   if (typeof json !== 'number') {
@@ -48,15 +48,10 @@ export function maximumValidator(this: ZSchemaBase, report: Report, schema: Json
 // exclusiveMaximum
 // ---------------------------------------------------------------------------
 
-export function exclusiveMaximumValidator(
-  this: ZSchemaBase,
-  report: Report,
-  schema: JsonSchemaInternal,
-  json: unknown
-) {
+export function exclusiveMaximumValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // In draft-06+, exclusiveMaximum is a standalone number
   if (typeof schema.exclusiveMaximum === 'number') {
-    if (shouldSkipValidate(this.validateOptions, ['MAXIMUM_EXCLUSIVE'])) {
+    if (shouldSkipValidate(ctx.validateOptions, ['MAXIMUM_EXCLUSIVE'])) {
       return;
     }
     if (typeof json !== 'number') {
@@ -73,9 +68,9 @@ export function exclusiveMaximumValidator(
 // minimum
 // ---------------------------------------------------------------------------
 
-export function minimumValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function minimumValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.1.3.2
-  if (shouldSkipValidate(this.validateOptions, ['MINIMUM', 'MINIMUM_EXCLUSIVE'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['MINIMUM', 'MINIMUM_EXCLUSIVE'])) {
     return;
   }
   if (typeof json !== 'number') {
@@ -94,15 +89,10 @@ export function minimumValidator(this: ZSchemaBase, report: Report, schema: Json
 // exclusiveMinimum
 // ---------------------------------------------------------------------------
 
-export function exclusiveMinimumValidator(
-  this: ZSchemaBase,
-  report: Report,
-  schema: JsonSchemaInternal,
-  json: unknown
-) {
+export function exclusiveMinimumValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // In draft-06+, exclusiveMinimum is a standalone number
   if (typeof schema.exclusiveMinimum === 'number') {
-    if (shouldSkipValidate(this.validateOptions, ['MINIMUM_EXCLUSIVE'])) {
+    if (shouldSkipValidate(ctx.validateOptions, ['MINIMUM_EXCLUSIVE'])) {
       return;
     }
     if (typeof json !== 'number') {

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -11,9 +11,9 @@ import { deferOrRunSync, shouldSkipValidate, supportsDependentKeywords } from '.
 // maxProperties
 // ---------------------------------------------------------------------------
 
-export function maxPropertiesValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function maxPropertiesValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.1.2
-  if (shouldSkipValidate(this.validateOptions, ['OBJECT_PROPERTIES_MAXIMUM'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['OBJECT_PROPERTIES_MAXIMUM'])) {
     return;
   }
   if (!isObject(json)) {
@@ -35,9 +35,9 @@ export function maxPropertiesValidator(this: ZSchemaBase, report: Report, schema
 // minProperties
 // ---------------------------------------------------------------------------
 
-export function minPropertiesValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function minPropertiesValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.2.2
-  if (shouldSkipValidate(this.validateOptions, ['OBJECT_PROPERTIES_MINIMUM'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['OBJECT_PROPERTIES_MINIMUM'])) {
     return;
   }
   if (!isObject(json)) {
@@ -59,9 +59,9 @@ export function minPropertiesValidator(this: ZSchemaBase, report: Report, schema
 // required
 // ---------------------------------------------------------------------------
 
-export function requiredValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function requiredValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.3.2
-  if (shouldSkipValidate(this.validateOptions, ['OBJECT_MISSING_REQUIRED_PROPERTY'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['OBJECT_MISSING_REQUIRED_PROPERTY'])) {
     return;
   }
   if (!isObject(json)) {
@@ -81,14 +81,14 @@ export function requiredValidator(this: ZSchemaBase, report: Report, schema: Jso
 // ---------------------------------------------------------------------------
 
 export function additionalPropertiesValidator(
-  this: ZSchemaBase,
+  ctx: ZSchemaBase,
   report: Report,
   schema: JsonSchemaInternal,
   json: unknown
 ) {
   // covered in properties and patternProperties
   if (schema.properties === undefined && schema.patternProperties === undefined) {
-    propertiesValidator.call(this, report, schema, json);
+    propertiesValidator(ctx, report, schema, json);
   }
 }
 
@@ -97,14 +97,14 @@ export function additionalPropertiesValidator(
 // ---------------------------------------------------------------------------
 
 export function patternPropertiesValidator(
-  this: ZSchemaBase,
+  ctx: ZSchemaBase,
   report: Report,
   schema: JsonSchemaInternal,
   json: unknown
 ) {
   // covered in properties
   if (schema.properties === undefined) {
-    propertiesValidator.call(this, report, schema, json);
+    propertiesValidator(ctx, report, schema, json);
   }
 }
 
@@ -112,9 +112,9 @@ export function patternPropertiesValidator(
 // properties
 // ---------------------------------------------------------------------------
 
-export function propertiesValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function propertiesValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.4.2
-  if (shouldSkipValidate(this.validateOptions, ['OBJECT_ADDITIONAL_PROPERTIES'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['OBJECT_ADDITIONAL_PROPERTIES'])) {
     return;
   }
   if (!isObject(json)) {
@@ -148,8 +148,8 @@ export function propertiesValidator(this: ZSchemaBase, report: Report, schema: J
     // Validation of the json succeeds if, after these two steps, set "s" is empty.
     if (s.length > 0) {
       // assumeAdditional can be an array of allowed properties
-      if (Array.isArray(this.options.assumeAdditional)) {
-        for (const allowed of this.options.assumeAdditional) {
+      if (Array.isArray(ctx.options.assumeAdditional)) {
+        for (const allowed of ctx.options.assumeAdditional) {
           const io = s.indexOf(allowed);
           if (io !== -1) {
             s.splice(io, 1);
@@ -169,9 +169,9 @@ export function propertiesValidator(this: ZSchemaBase, report: Report, schema: J
 // dependencies
 // ---------------------------------------------------------------------------
 
-export function dependenciesValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function dependenciesValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.5.2
-  if (shouldSkipValidate(this.validateOptions, ['OBJECT_DEPENDENCY_KEY'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['OBJECT_DEPENDENCY_KEY'])) {
     return;
   }
   if (!isObject(json)) {
@@ -200,7 +200,7 @@ export function dependenciesValidator(this: ZSchemaBase, report: Report, schema:
         }
       } else {
         // if dependency is a schema, validate against this schema
-        this._jsonValidate(report, dependencyDefinition, json);
+        ctx._jsonValidate(report, dependencyDefinition, json);
       }
     }
   }
@@ -210,13 +210,8 @@ export function dependenciesValidator(this: ZSchemaBase, report: Report, schema:
 // dependentSchemas
 // ---------------------------------------------------------------------------
 
-export function dependentSchemasValidator(
-  this: ZSchemaBase,
-  report: Report,
-  schema: JsonSchemaInternal,
-  json: unknown
-) {
-  if (!supportsDependentKeywords(schema, this.options.version)) {
+export function dependentSchemasValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+  if (!supportsDependentKeywords(schema, ctx.options.version)) {
     return;
   }
   if (!isObject(json) || !isObject(schema.dependentSchemas)) {
@@ -228,7 +223,7 @@ export function dependentSchemasValidator(
   for (const dependencyName of keys) {
     if (Object.hasOwn(json, dependencyName)) {
       const dependencySchema = schema.dependentSchemas[dependencyName];
-      this._jsonValidate(report, dependencySchema, json);
+      ctx._jsonValidate(report, dependencySchema, json);
     }
   }
 }
@@ -238,15 +233,15 @@ export function dependentSchemasValidator(
 // ---------------------------------------------------------------------------
 
 export function dependentRequiredValidator(
-  this: ZSchemaBase,
+  ctx: ZSchemaBase,
   report: Report,
   schema: JsonSchemaInternal,
   json: unknown
 ) {
-  if (!supportsDependentKeywords(schema, this.options.version)) {
+  if (!supportsDependentKeywords(schema, ctx.options.version)) {
     return;
   }
-  if (shouldSkipValidate(this.validateOptions, ['OBJECT_DEPENDENCY_KEY'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['OBJECT_DEPENDENCY_KEY'])) {
     return;
   }
   if (!isObject(json) || !isObject(schema.dependentRequired)) {
@@ -283,8 +278,8 @@ export function dependentRequiredValidator(
 // propertyNames
 // ---------------------------------------------------------------------------
 
-export function propertyNamesValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
-  if (shouldSkipValidate(this.validateOptions, ['PROPERTY_NAMES'])) {
+export function propertyNamesValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+  if (shouldSkipValidate(ctx.validateOptions, ['PROPERTY_NAMES'])) {
     return;
   }
 
@@ -303,7 +298,7 @@ export function propertyNamesValidator(this: ZSchemaBase, report: Report, schema
   for (const key of keys) {
     const subReport = new Report_(report);
     subReports.push(subReport);
-    this._jsonValidate(subReport, propertyNamesSchema as any, key);
+    ctx._jsonValidate(subReport, propertyNamesSchema as any, key);
   }
 
   const addPropertyNameErrors = () => {

--- a/src/validation/shared.ts
+++ b/src/validation/shared.ts
@@ -9,7 +9,7 @@ import { isObject } from '../utils/what-is.js';
 // Shared types
 // ---------------------------------------------------------------------------
 
-export type JsonValidatorFn = (this: ZSchemaBase, report: Report, schema: JsonSchema, json: unknown) => void;
+export type JsonValidatorFn = (ctx: ZSchemaBase, report: Report, schema: JsonSchema, json: unknown) => void;
 
 // ---------------------------------------------------------------------------
 // Draft / vocabulary helpers

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -13,9 +13,9 @@ import { isFormatAssertionVocabEnabled, shouldSkipValidate } from './shared.js';
 // minLength
 // ---------------------------------------------------------------------------
 
-export function minLengthValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function minLengthValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.2.2
-  if (shouldSkipValidate(this.validateOptions, ['MIN_LENGTH'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['MIN_LENGTH'])) {
     return;
   }
   if (typeof json !== 'string') {
@@ -30,9 +30,9 @@ export function minLengthValidator(this: ZSchemaBase, report: Report, schema: Js
 // maxLength
 // ---------------------------------------------------------------------------
 
-export function maxLengthValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function maxLengthValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.1.2
-  if (shouldSkipValidate(this.validateOptions, ['MAX_LENGTH'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['MAX_LENGTH'])) {
     return;
   }
   if (typeof json !== 'string') {
@@ -47,9 +47,9 @@ export function maxLengthValidator(this: ZSchemaBase, report: Report, schema: Js
 // pattern
 // ---------------------------------------------------------------------------
 
-export function patternValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function patternValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.3.2
-  if (shouldSkipValidate(this.validateOptions, ['PATTERN'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['PATTERN'])) {
     return;
   }
   if (typeof json !== 'string') {
@@ -70,24 +70,24 @@ export function patternValidator(this: ZSchemaBase, report: Report, schema: Json
 // format
 // ---------------------------------------------------------------------------
 
-export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function formatValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.2
-  if (this.options.formatAssertions === false) {
+  if (ctx.options.formatAssertions === false) {
     return;
   }
 
   // When formatAssertions is explicitly true, respect the meta-schema vocabulary:
   // for draft 2019-09/2020-12, format is annotation-only unless the format-assertion
   // vocabulary is enabled in the meta-schema.
-  if (this.options.formatAssertions === true && !isFormatAssertionVocabEnabled(schema, report, this.options.version)) {
+  if (ctx.options.formatAssertions === true && !isFormatAssertionVocabEnabled(schema, report, ctx.options.version)) {
     return;
   }
 
-  const isModernDraft = this.options.version === 'draft2019-09' || this.options.version === 'draft2020-12';
+  const isModernDraft = ctx.options.version === 'draft2019-09' || ctx.options.version === 'draft2020-12';
 
-  const formatValidatorFn = resolveFormatValidator(schema.format!, this.options);
+  const formatValidatorFn = resolveFormatValidator(schema.format!, ctx.options);
   if (typeof formatValidatorFn === 'function') {
-    if (shouldSkipValidate(this.validateOptions, ['INVALID_FORMAT'])) {
+    if (shouldSkipValidate(ctx.validateOptions, ['INVALID_FORMAT'])) {
       return;
     }
     if (report.hasError('INVALID_TYPE', [schema.type, whatIs(json)])) {
@@ -101,7 +101,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
         }
       });
     } else {
-      const result = formatValidatorFn.call(this, json);
+      const result = formatValidatorFn.call(ctx, json);
       if (result instanceof Promise) {
         // Promise-based async
         const promiseResult = result;
@@ -126,7 +126,7 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
         report.addError('INVALID_FORMAT', [schema.format!, JSON.stringify(json)], undefined, schema, 'format');
       }
     }
-  } else if (this.options.ignoreUnknownFormats !== true && !isModernDraft) {
+  } else if (ctx.options.ignoreUnknownFormats !== true && !isModernDraft) {
     report.addError('UNKNOWN_FORMAT', [schema.format!], undefined, schema, 'format');
   }
 }
@@ -135,8 +135,8 @@ export function formatValidator(this: ZSchemaBase, report: Report, schema: JsonS
 // contentEncoding
 // ---------------------------------------------------------------------------
 
-export function contentEncodingValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
-  if (this.options.version !== 'draft-07') {
+export function contentEncodingValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+  if (ctx.options.version !== 'draft-07') {
     return;
   }
   if (typeof json !== 'string') {
@@ -163,13 +163,8 @@ export function contentEncodingValidator(this: ZSchemaBase, report: Report, sche
 // contentMediaType
 // ---------------------------------------------------------------------------
 
-export function contentMediaTypeValidator(
-  this: ZSchemaBase,
-  report: Report,
-  schema: JsonSchemaInternal,
-  json: unknown
-) {
-  if (this.options.version !== 'draft-07') {
+export function contentMediaTypeValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+  if (ctx.options.version !== 'draft-07') {
     return;
   }
   if (typeof json !== 'string') {

--- a/src/validation/type.ts
+++ b/src/validation/type.ts
@@ -10,9 +10,9 @@ import { shouldSkipValidate } from './shared.js';
 // type
 // ---------------------------------------------------------------------------
 
-export function typeValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function typeValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.2.2
-  if (shouldSkipValidate(this.validateOptions, ['INVALID_TYPE'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['INVALID_TYPE'])) {
     return;
   }
   const jsonType = whatIs(json);
@@ -29,13 +29,13 @@ export function typeValidator(this: ZSchemaBase, report: Report, schema: JsonSch
 // enum
 // ---------------------------------------------------------------------------
 
-export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function enumValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.1.2
-  if (shouldSkipValidate(this.validateOptions, ['ENUM_CASE_MISMATCH', 'ENUM_MISMATCH'])) {
+  if (shouldSkipValidate(ctx.validateOptions, ['ENUM_CASE_MISMATCH', 'ENUM_MISMATCH'])) {
     return;
   }
-  const eqOpts = { maxDepth: this.options.maxRecursionDepth };
-  const eqOptsCI = { caseInsensitiveComparison: true, maxDepth: this.options.maxRecursionDepth };
+  const eqOpts = { maxDepth: ctx.options.maxRecursionDepth };
+  const eqOptsCI = { caseInsensitiveComparison: true, maxDepth: ctx.options.maxRecursionDepth };
   let caseInsensitiveMatch = false,
     match = false;
   for (const enumVal of schema.enum!) {
@@ -49,7 +49,7 @@ export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSch
 
   if (!match) {
     const error =
-      caseInsensitiveMatch && this.options.enumCaseInsensitiveComparison ? 'ENUM_CASE_MISMATCH' : 'ENUM_MISMATCH';
+      caseInsensitiveMatch && ctx.options.enumCaseInsensitiveComparison ? 'ENUM_CASE_MISMATCH' : 'ENUM_MISMATCH';
     report.addError(error, [JSON.stringify(json)], undefined, schema, 'enum');
   }
 }
@@ -58,9 +58,9 @@ export function enumValidator(this: ZSchemaBase, report: Report, schema: JsonSch
 // const
 // ---------------------------------------------------------------------------
 
-export function constValidator(this: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
+export function constValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: unknown) {
   const constValue = schema.const;
-  if (!areEqual(json, constValue, { maxDepth: this.options.maxRecursionDepth })) {
+  if (!areEqual(json, constValue, { maxDepth: ctx.options.maxRecursionDepth })) {
     report.addError('CONST', [JSON.stringify(constValue)], undefined, schema);
   }
 }

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -65,7 +65,7 @@ export class ZSchemaBase {
    * create a circular dependency).
    */
   _jsonValidate(report: Report, schema: boolean | JsonSchemaInternal, json: unknown): boolean {
-    return validateJson.call(this, report, schema, json);
+    return validateJson(this, report, schema, json);
   }
 
   getDefaultSchemaId(): string {
@@ -160,7 +160,7 @@ export class ZSchemaBase {
     }
 
     if (!foundError) {
-      validateJson.call(this, report, _schema, json);
+      validateJson(this, report, _schema, json);
     }
 
     if (callback) {


### PR DESCRIPTION
## What

Enables the `oxc/no-this-in-exported-function` oxlint rule (removed from the TODO backlog) by replacing the implicit `this: ZSchemaBase` this-parameter on the exported validator functions with an explicit leading `ctx: ZSchemaBase` parameter.

- `JsonValidatorFn` (the single source-of-truth type) now takes `ctx` as its first parameter, so `tsc` flags every implementer and call site.
- All ~30 exported keyword validators in `src/validation/*.ts` and the exported `validate` + traversal helpers in `json-validation.ts` take `ctx`.
- `JsonValidators` dispatch and the internal helpers now call `validate(ctx, ...)` / `validator(ctx, ...)` directly instead of `.call(this, ...)`.
- `z-schema-base` entry points and the `schema-validator` call sites pass the instance as `ctx`.

## Public API preserved

- Emitted public `.d.ts` is **byte-identical** to `main` (verified by diff).
- The user-facing callback contracts are unchanged: `customValidator` and user-registered **format validators** are still invoked via `.call(ctx, ...)`, so they continue to receive the validator instance as `this`.

## Behavior preservation

`ctx` is the same `ZSchemaBase` reference that `this` was — no logic, ordering, short-circuit, or error-path changes. Replacing `.call()` with direct calls is a small perf win with no new allocations (aligns with the AGENTS.md hot-path rules).

## Also

Tightens the #431 `promise/prefer-await-to-callbacks` rationale comment: drops the inaccurate `(str, callback)` format-validator claim (`FormatValidatorFn` is `(input: unknown) => boolean | Promise<boolean>`); the genuine public callback contracts are `ValidateCallback` and `Report.processAsyncTasks` (addresses the Codex review note on #431).

## Verification

- `npx oxlint --type-aware` → clean (exit 0), `no-this` count in `src/` = 0.
- `tsc --noEmit` (src) → no new errors.
- `npm run build` + `npm run build:tests` → pass.
- `npm test` → **32389 passed** (node + browser).
- Public `.d.ts` diff vs `main` → identical.