### PR TITLE
refactor: enable typescript/no-unsafe-return

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -112,14 +112,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows assigning `any`-typed values to typed variables or properties.
     'typescript/no-unsafe-assignment': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 3
-    // complexity: dangerous
-    // Functions return `any`-typed values where a typed return is expected; fixing requires narrowing the returned types.
-    // type: type-safety
-    // Disallows returning `any`-typed values from functions with non-`any` return type annotations.
-    'typescript/no-unsafe-return': 'off',
   },
   overrides: [
     {
@@ -130,6 +122,7 @@ export default defineConfig({
         // Legacy ZSchemaTestSuite fixtures are intentionally loosely typed
         // (hooks receive arbitrary validator/error shapes); not worth retyping.
         'typescript/no-unsafe-call': 'off',
+        'typescript/no-unsafe-return': 'off',
       },
     },
   ],

--- a/src/report.ts
+++ b/src/report.ts
@@ -250,7 +250,7 @@ export class Report {
     // try to find id in the error path
     while (path.length > 0) {
       const obj = get(this.rootSchema, path);
-      if (obj && obj.id) {
+      if (isObject(obj) && typeof obj.id === 'string') {
         return obj.id;
       }
       path.pop();

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -63,9 +63,9 @@ export const isUniqueArray = (arr: unknown[], indexes?: number[], maxDepth?: num
   return true;
 };
 
-export const difference = (bigSet: any[], subSet: any[]) => {
+export const difference = <T>(bigSet: readonly T[], subSet: readonly T[]): T[] => {
   const exclusions = new Set(subSet);
-  const arr = [];
+  const arr: T[] = [];
   let idx = bigSet.length;
   while (idx--) {
     if (!exclusions.has(bigSet[idx])) {

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -5,26 +5,25 @@ export const shallowClone = <T>(src: T): T => {
   if (src == null || typeof src !== 'object') {
     return src;
   }
-  let res: any;
   if (Array.isArray(src)) {
-    res = [];
+    const res: unknown[] = [];
     for (let i = 0; i < src.length; i++) {
       res[i] = src[i];
     }
-  } else {
-    res = {};
-    const keys = Object.keys(src).sort() as Array<keyof T>;
-    for (let i = 0; i < keys.length; i++) {
-      copyProp(src, res, keys[i]);
-    }
+    return res as T;
   }
-  return res;
+  const res: Record<string, unknown> = {};
+  const keys = Object.keys(src).sort() as Array<keyof T>;
+  for (let i = 0; i < keys.length; i++) {
+    copyProp(src, res, keys[i]);
+  }
+  return res as T;
 };
 
 export const deepClone = <T>(src: T, maxDepth = DEFAULT_MAX_RECURSION_DEPTH): T => {
   let vidx = 0;
   const visited = new Map();
-  const cloned: any[] = [];
+  const cloned: unknown[] = [];
   const cloneDeepInner = <U>(node: U, _depth: number): U => {
     if (typeof node !== 'object' || node === null) {
       return node;
@@ -37,29 +36,28 @@ export const deepClone = <T>(src: T, maxDepth = DEFAULT_MAX_RECURSION_DEPTH): T 
       );
     }
 
-    let res: any;
     const cidx = visited.get(node);
 
     if (cidx !== undefined) {
-      return cloned[cidx];
+      return cloned[cidx] as U;
     }
 
     visited.set(node, vidx++);
     if (Array.isArray(node)) {
-      res = [];
+      const res: unknown[] = [];
       cloned.push(res);
       for (let i = 0; i < node.length; i++) {
         res[i] = cloneDeepInner(node[i], _depth + 1);
       }
-    } else {
-      res = {};
-      cloned.push(res);
-      const keys = Object.keys(node).sort() as Array<keyof U>;
-      for (let i = 0; i < keys.length; i++) {
-        copyProp(node, res, keys[i], (v: any) => cloneDeepInner(v, _depth + 1));
-      }
+      return res as U;
     }
-    return res;
+    const res: Record<string, unknown> = {};
+    cloned.push(res);
+    const keys = Object.keys(node).sort() as Array<keyof U>;
+    for (let i = 0; i < keys.length; i++) {
+      copyProp(node, res, keys[i], (v: unknown) => cloneDeepInner(v, _depth + 1));
+    }
+    return res as U;
   };
   return cloneDeepInner(src, 0);
 };

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -1,4 +1,4 @@
-export function copyProp(from: object, to: object, key: string | number | symbol, fn?: <T>(obj: T) => T) {
+export function copyProp(from: object, to: object, key: string | number | symbol, fn?: (value: unknown) => unknown) {
   if (Object.hasOwn(from, key)) {
     Object.defineProperty(to, key, {
       value: fn ? fn((from as any)[key]) : (from as any)[key],


### PR DESCRIPTION
## What

Enables `typescript/no-unsafe-return` (removed from the TODO backlog). The 6 `src/` sites are fixed by replacing internal `any` working types with concrete ones:

- **[clone.ts](src/utils/clone.ts)**: `shallowClone`/`deepClone` use `unknown[]` / `Record<string, unknown>` working vars instead of `any`, with a single `as T`/`as U` assertion at each return — the unavoidable generic-clone cast, to be reviewed under `no-unsafe-type-assertion` (PR 8). Cyclic-ref memoization and behavior unchanged.
- **[array.ts](src/utils/array.ts)**: `difference` is now generic `<T>(readonly T[], readonly T[]) => T[]` (its sole caller passes `string[]`), returning `T[]` not `any[]`.
- **[properties.ts](src/utils/properties.ts)**: `copyProp`'s transform param retyped `<T>(obj: T) => T` → `(value: unknown) => unknown`, letting `deepClone`'s clone callback return `unknown` instead of `any`.
- **[report.ts](src/report.ts)**: `getSchemaId` narrows the `get()` result with `isObject` + `typeof obj.id === 'string'`, returning a real `string` (was `any`) — type-honest for the `string | undefined` contract.

Legacy `test/` fixtures (3 sites) suppressed via the existing `test/**` override.

## Verification

- `npx oxlint --type-aware` → clean (exit 0); `no-unsafe-return` count in `src/` = 0.
- `tsc --noEmit` (src) → clean. `npm run build` + `npm run build:tests` → pass.
- `npm test` → **32389 passed**.
- Public `.d.ts` diff vs `main` → **identical**.