### PR TITLE
refactor: enable typescript/no-unsafe-assignment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,12 @@ jobs:
         run: git submodule update --init
       - name: Install dependencies
         run: npm ci
+      - name: Copy bundled schemas
+        # Generates src/schemas/*.json from the json-schema-spec submodule.
+        # Required before `check`: the type-aware lint resolves the JSON imports
+        # in z-schema-versions.ts, which are absent on a fresh checkout until the
+        # build's copy:schemas step runs.
+        run: npm run copy:schemas
       - name: Check (lint + format)
         run: npm run check
       - name: Build

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -23,7 +23,7 @@ Line coverage status: **high**
 | src/utils/hostname.ts         |    100% |        100% |       100% |     100% |
 | src/utils/json.ts             |     98% |         98% |       100% |      97% |
 | src/utils/properties.ts       |    100% |        100% |       100% |      75% |
-| src/utils/schema-regex.ts     |     94% |         94% |       100% |      71% |
+| src/utils/schema-regex.ts     |     94% |         94% |       100% |      77% |
 | src/utils/symbols.ts          |    100% |        100% |       100% |     100% |
 | src/utils/time.ts             |     97% |         97% |       100% |      95% |
 | src/utils/unicode.ts          |    100% |        100% |       100% |     100% |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -104,14 +104,6 @@ export default defineConfig({
     // type: type-safety
     // Disallows passing `any`-typed values as arguments to typed function parameters.
     'typescript/no-unsafe-argument': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 11
-    // complexity: dangerous
-    // Values typed as `any` are assigned to typed variables; fixing requires narrowing the source types throughout the codebase.
-    // type: type-safety
-    // Disallows assigning `any`-typed values to typed variables or properties.
-    'typescript/no-unsafe-assignment': 'off',
   },
   overrides: [
     {
@@ -123,6 +115,7 @@ export default defineConfig({
         // (hooks receive arbitrary validator/error shapes); not worth retyping.
         'typescript/no-unsafe-call': 'off',
         'typescript/no-unsafe-return': 'off',
+        'typescript/no-unsafe-assignment': 'off',
       },
     },
   ],

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -639,7 +639,7 @@ function recurseArray(ctx: ZSchemaBase, report: Report, schema: JsonSchemaIntern
 // recurseObject
 // ---------------------------------------------------------------------------
 
-function recurseObject(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Record<any, any>) {
+function recurseObject(ctx: ZSchemaBase, report: Report, schema: JsonSchemaInternal, json: Record<string, unknown>) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3
 
   // If "additionalProperties" is absent, it is considered present with an empty schema as a value.

--- a/src/schema-cache.ts
+++ b/src/schema-cache.ts
@@ -43,8 +43,9 @@ export function prepareRemoteSchema(
   validationOptions?: ZSchemaOptions,
   maxCloneDepth?: number
 ): JsonSchemaInternal {
-  const _schema: JsonSchemaInternal =
-    typeof schema === 'string' ? JSON.parse(schema) : deepClone(schema, maxCloneDepth);
+  const _schema = (
+    typeof schema === 'string' ? JSON.parse(schema) : deepClone(schema, maxCloneDepth)
+  ) as JsonSchemaInternal;
 
   if (!_schema.id) {
     _schema.id = uri;
@@ -58,8 +59,8 @@ export function prepareRemoteSchema(
 }
 
 export class SchemaCache {
-  static global_cache: SchemaCacheStorage = Object.create(null);
-  cache: SchemaCacheStorage = Object.create(null);
+  static global_cache: SchemaCacheStorage = Object.create(null) as SchemaCacheStorage;
+  cache: SchemaCacheStorage = Object.create(null) as SchemaCacheStorage;
   private readonly validator: ZSchemaBase;
 
   constructor(validator: ZSchemaBase) {

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -135,7 +135,7 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
       const id: Id = {
         id: nodeId,
         type,
-        obj: node,
+        obj: node as JsonSchemaInternal,
       };
       if (type === 'absolute' || (type === 'root' && isAbsoluteUri(nodeId))) {
         id.absoluteUri = nodeId;

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -22,7 +22,7 @@ export const shallowClone = <T>(src: T): T => {
 
 export const deepClone = <T>(src: T, maxDepth = DEFAULT_MAX_RECURSION_DEPTH): T => {
   let vidx = 0;
-  const visited = new Map();
+  const visited = new Map<unknown, number>();
   const cloned: unknown[] = [];
   const cloneDeepInner = <U>(node: U, _depth: number): U => {
     if (typeof node !== 'object' || node === null) {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -80,15 +80,15 @@ export const areEqual = (json1: unknown, json2: unknown, options?: AreEqualOptio
 export const decodeJSONPointer = (str: string) =>
   decodeURIComponent(str).replaceAll(/~[0-1]/g, (x) => (x === '~1' ? '/' : '~'));
 
-export const get = (obj: any, path: string | Array<string | number>): any => {
+export const get = (obj: unknown, path: string | Array<string | number>): unknown => {
   if (typeof path === 'string') {
     path = path.split('.');
   }
-  let acc: any = obj;
+  let acc: unknown = obj;
   for (let i = 0; i < path.length; i++) {
     const key = path[i];
-    if (acc && acc[key] !== undefined) {
-      acc = acc[key];
+    if (acc && (acc as Record<string | number, unknown>)[key] !== undefined) {
+      acc = (acc as Record<string | number, unknown>)[key];
     } else {
       return undefined;
     }

--- a/src/utils/schema-regex.ts
+++ b/src/utils/schema-regex.ts
@@ -40,12 +40,12 @@ export function compileSchemaRegex(
     try {
       const re = new RegExp(pattern, 'u');
       return { ok: true, value: re };
-    } catch (error: any) {
+    } catch (error: unknown) {
       return {
         ok: false,
         error: {
           pattern,
-          message: error && error.message ? error.message : 'Invalid regular expression',
+          message: error instanceof Error ? error.message : 'Invalid regular expression',
         },
       };
     }
@@ -53,12 +53,12 @@ export function compileSchemaRegex(
     try {
       const re = new RegExp(pattern);
       return { ok: true, value: re };
-    } catch (error: any) {
+    } catch (error: unknown) {
       return {
         ok: false,
         error: {
           pattern,
-          message: error && error.message ? error.message : 'Invalid regular expression',
+          message: error instanceof Error ? error.message : 'Invalid regular expression',
         },
       };
     }

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -146,7 +146,7 @@ export class ZSchemaBase {
 
     if (options.schemaPath) {
       report.rootSchema = _schema;
-      _schema = get(_schema, options.schemaPath);
+      _schema = get(_schema, options.schemaPath) as JsonSchemaInternal;
       if (!_schema) {
         const e = new Error(`Schema path '${options.schemaPath}' wasn't found in the schema!`);
         if (callback) {
@@ -328,8 +328,8 @@ export class ZSchemaBase {
       visited.add(node);
 
       if (node.$ref && node.__$refResolved) {
-        const from = node.__$refResolved;
-        const to = node;
+        const from = node.__$refResolved as JsonSchemaInternal;
+        const to = node as JsonSchemaInternal;
         delete node.$ref;
         delete node.__$refResolved;
         for (key in from) {


### PR DESCRIPTION
## What

Enables `typescript/no-unsafe-assignment` (removed from the TODO backlog). The 14 `src/` sites are fixed by tightening source types.

**Clean root fixes (no cast):**
- **[json.ts](src/utils/json.ts)** `get()`: `obj`/return/`acc` typed `unknown` (indexing via a localized `Record` narrowing, preserving the exact `acc &&` truthiness). Both callers handled — `report.ts` already narrows with `isObject`; `z-schema-base` casts the result.
- **[clone.ts](src/utils/clone.ts)**: `deepClone`'s `visited` map typed `Map<unknown, number>` so the memo index is `number`, not `any`.
- **[schema-regex.ts](src/utils/schema-regex.ts)**: `catch (error: unknown)` + `error instanceof Error ? error.message : default`.
- **[json-validation.ts](src/json-validation.ts)**: `recurseObject`'s `json` param `Record<any, any>` → `Record<string, unknown>`.

**Localized assertions** (the `any`-typed traversal/parse sites — to be reviewed under `no-unsafe-type-assertion`, PR 8):
- **[schema-cache.ts](src/schema-cache.ts)**: `JSON.parse` / `Object.create(null)` results asserted to their declared types.
- **[schema-compiler.ts](src/schema-compiler.ts)**: `Id.obj` = `node as JsonSchemaInternal` (matches the existing `node as` cast in `collectIds`).
- **[z-schema-base.ts](src/z-schema-base.ts)**: `get()` result and the cleanup-closure `node`/`__$refResolved` asserted to `JsonSchemaInternal`.

Legacy `test/` fixtures (6 sites) suppressed via the existing `test/**` override.

## Verification

- `npx oxlint --type-aware` → clean (exit 0); `no-unsafe-assignment` count in `src/` = 0.
- `tsc --noEmit` (src) → clean. `npm run build` + `npm run build:tests` → pass.
- `npm test` → **32389 passed**.
- Public `.d.ts` diff vs `main` → **identical**.