### PR TITLE
refactor: enable typescript/no-unsafe-argument

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -96,14 +96,6 @@ export default defineConfig({
     // type: type-safety
     // Flags type assertions that bypass the type checker (notably assertions to/from `any`), which can mask runtime errors.
     'typescript/no-unsafe-type-assertion': 'off',
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 13
-    // complexity: dangerous
-    // Arguments typed as `any` are passed into typed parameters; fixing requires narrowing the source types or adding explicit casts.
-    // type: type-safety
-    // Disallows passing `any`-typed values as arguments to typed function parameters.
-    'typescript/no-unsafe-argument': 'off',
   },
   overrides: [
     {
@@ -116,6 +108,7 @@ export default defineConfig({
         'typescript/no-unsafe-call': 'off',
         'typescript/no-unsafe-return': 'off',
         'typescript/no-unsafe-assignment': 'off',
+        'typescript/no-unsafe-argument': 'off',
       },
     },
   ],

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -154,7 +154,7 @@ export const findId = (
   let result;
   if (Array.isArray(schema)) {
     for (let i = 0; i < schema.length; i++) {
-      result = findId(schema[i], id, targetBaseUri, nextBaseUri, maxDepth, _depth + 1);
+      result = findId(schema[i] as JsonSchemaInternal, id, targetBaseUri, nextBaseUri, maxDepth, _depth + 1);
       if (result) {
         return result;
       }

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -139,8 +139,13 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
       };
       if (type === 'absolute' || (type === 'root' && isAbsoluteUri(nodeId))) {
         id.absoluteUri = nodeId;
-      } else if (type === 'root' && typeof node.id === 'string' && isAbsoluteUri(node.id) && node.id !== nodeId) {
-        id.absoluteUri = resolveSchemaScopeId(node.id, node as JsonSchemaInternal, nodeId);
+      } else if (
+        type === 'root' &&
+        typeof node.id === 'string' &&
+        isAbsoluteUri(node.id as string) &&
+        node.id !== nodeId
+      ) {
+        id.absoluteUri = resolveSchemaScopeId(node.id as string, node as JsonSchemaInternal, nodeId);
       } else if (type === 'relative') {
         let absoluteParent: Id | undefined;
         for (let i = scope.length - 1; i >= 0; i--) {
@@ -166,7 +171,7 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
         walk(item, scope, _depth + 1);
       }
     } else {
-      for (const key of Object.keys(node)) {
+      for (const key of Object.keys(node as object)) {
         if (isInternalKey(key) || NON_SCHEMA_KEYWORDS_SET.has(key)) {
           continue;
         }
@@ -265,7 +270,7 @@ export const collectReferences = (
   if (Array.isArray(obj)) {
     for (let i = 0; i < obj.length; i++) {
       path.push(i);
-      collectReferences(obj[i], results, scope, path, options, maxDepth, _depth + 1);
+      collectReferences(obj[i] as JsonSchemaInternal, results, scope, path, options, maxDepth, _depth + 1);
       path.pop();
     }
   } else {
@@ -276,7 +281,15 @@ export const collectReferences = (
         continue;
       }
       path.push(key);
-      collectReferences((obj as any)[key], results, scope, path, options, maxDepth, _depth + 1);
+      collectReferences(
+        (obj as Record<string, JsonSchemaInternal>)[key],
+        results,
+        scope,
+        path,
+        options,
+        maxDepth,
+        _depth + 1
+      );
       path.pop();
     }
   }

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -118,7 +118,7 @@ export function containsValidator(ctx: ZSchemaBase, report: Report, schema: Json
   for (let idx = 0; idx < json.length; idx++) {
     const subReport = new Report_(report);
     subReports.push(subReport);
-    ctx._jsonValidate(subReport, containsSchema as any, json[idx]);
+    ctx._jsonValidate(subReport, containsSchema as JsonSchemaInternal, json[idx]);
     cacheValidationResult(report, containsSchema, json[idx], subReport.errors.length === 0);
   }
 

--- a/src/validation/combinators.ts
+++ b/src/validation/combinators.ts
@@ -111,7 +111,7 @@ export function ifValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchema
   }
 
   const conditionReport = new Report(report);
-  ctx._jsonValidate(conditionReport, conditionSchema as any, json);
+  ctx._jsonValidate(conditionReport, conditionSchema as JsonSchemaInternal, json);
   cacheValidationResult(report, conditionSchema, json, conditionReport.errors.length === 0);
 
   const branchSchema = conditionReport.errors.length === 0 ? thenSchema : elseSchema;
@@ -119,7 +119,7 @@ export function ifValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchema
     return;
   }
 
-  ctx._jsonValidate(report, branchSchema as any, json);
+  ctx._jsonValidate(report, branchSchema as JsonSchemaInternal, json);
 }
 
 export function thenValidator() {

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -298,7 +298,7 @@ export function propertyNamesValidator(ctx: ZSchemaBase, report: Report, schema:
   for (const key of keys) {
     const subReport = new Report_(report);
     subReports.push(subReport);
-    ctx._jsonValidate(subReport, propertyNamesSchema as any, key);
+    ctx._jsonValidate(subReport, propertyNamesSchema as JsonSchemaInternal, key);
   }
 
   const addPropertyNameErrors = () => {

--- a/src/validation/shared.ts
+++ b/src/validation/shared.ts
@@ -181,7 +181,7 @@ export function deferOrRunSync(report: Report, subReports: Report[], decisionFn:
           callback(null);
         }, 0);
       },
-      [] as any,
+      [],
       () => {
         decisionFn();
       }

--- a/src/validation/string.ts
+++ b/src/validation/string.ts
@@ -114,7 +114,7 @@ export function formatValidator(ctx: ZSchemaBase, report: Report, schema: JsonSc
               callback(false);
             }
           },
-          [] as any,
+          [],
           (resolvedResult) => {
             if (resolvedResult !== true) {
               report.addError('INVALID_FORMAT', [schema.format!, JSON.stringify(json)], undefined, schema, 'format');

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -321,11 +321,11 @@ export class ZSchemaBase {
         return;
       }
 
-      if (visited.has(node)) {
+      if (visited.has(node as object)) {
         return;
       }
 
-      visited.add(node);
+      visited.add(node as object);
 
       if (node.$ref && node.__$refResolved) {
         const from = node.__$refResolved as JsonSchemaInternal;
@@ -339,7 +339,7 @@ export class ZSchemaBase {
         }
       }
       for (key in node) {
-        if (Object.hasOwn(node, key)) {
+        if (Object.hasOwn(node as object, key)) {
           if (isInternalKey(key)) {
             delete node[key];
           } else {


### PR DESCRIPTION
## What

Enables `typescript/no-unsafe-argument` (removed from the TODO backlog). The 15 `src/` sites are fixed by passing typed values instead of `any`.

**Clean fixes (remove the `any`):**
- **validation [array](src/validation/array.ts)/[combinators](src/validation/combinators.ts)/[object](src/validation/object.ts)**: subschema args to `_jsonValidate` were `X as any`; now `X as JsonSchemaInternal` (`contains`/`if`/`then`-`else`/`propertyNames`).
- **validation [shared](src/validation/shared.ts)/[string](src/validation/string.ts)**: empty async-task args `[] as any` → just `[]` (assignable to the `any[]` param without an assertion).
- **[schema-compiler](src/schema-compiler.ts)** `collectReferences`: `(obj as any)[key]` → `(obj as Record<string, JsonSchemaInternal>)[key]` — a typed value, not `any`.

**Localized assertions** at the `any`-typed traversal boundaries (the `walk`/`cleanup` closures keep their intentional `node: any`; reviewed under `no-unsafe-type-assertion`, PR 8):
- `collectIds.walk`: string-guarded `node.id as string` for `isAbsoluteUri`/`resolveSchemaScopeId`; `Object.keys(node as object)`.
- `collectReferences` / `findId`: array-element recurse args `as JsonSchemaInternal` (matches the existing sibling cast).
- `z-schema-base` cleanup closure: `visited.has/add` and `Object.hasOwn` receive `node as object`.

Legacy `test/` fixtures (14 sites) suppressed via the existing `test/**` override.

## Verification

- `npx oxlint --type-aware` → clean (exit 0); `no-unsafe-argument` count in `src/` = 0.
- `tsc --noEmit` (src) → clean. `npm run build` + `npm run build:tests` → pass.
- `npm test` → **32389 passed**.
- Public `.d.ts` diff vs `main` → **identical**.