### PR TITLE
refactor: enable typescript/no-unsafe-member-access

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -37,7 +37,7 @@ Line coverage status: **high**
 | src/validation/shared.ts      |     93% |         93% |       100% |      83% |
 | src/validation/string.ts      |     90% |         90% |       100% |      89% |
 | src/validation/type.ts        |    100% |        100% |       100% |      96% |
-| src/z-schema-base.ts          |     86% |         87% |        89% |      80% |
+| src/z-schema-base.ts          |     87% |         87% |        89% |      80% |
 | src/z-schema-options.ts       |     92% |         92% |       100% |      70% |
 | src/z-schema-reader.ts        |    100% |        100% |       100% |     100% |
 | src/z-schema-versions.ts      |    100% |        100% |       100% |      75% |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -82,14 +82,6 @@ export default defineConfig({
     // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
 
     // TODO: evaluate this rule in the future
-    // occurrences in codebase: 105
-    // complexity: dangerous
-    // Member access on `any`-typed values is common in schema traversal code; fixing requires narrowing types or adding casts throughout.
-    // type: type-safety
-    // Disallows accessing properties on values typed as `any`, which bypasses TypeScript's type checking.
-    'typescript/no-unsafe-member-access': 'off',
-
-    // TODO: evaluate this rule in the future
     // occurrences in codebase: 23
     // complexity: dangerous
     // Most sites assert values to `any` or narrow types; tightening requires real upstream typing work.
@@ -109,6 +101,7 @@ export default defineConfig({
         'typescript/no-unsafe-return': 'off',
         'typescript/no-unsafe-assignment': 'off',
         'typescript/no-unsafe-argument': 'off',
+        'typescript/no-unsafe-member-access': 'off',
       },
     },
   ],

--- a/src/schema-compiler.ts
+++ b/src/schema-compiler.ts
@@ -117,6 +117,8 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
       return;
     }
 
+    const schemaNode = node as JsonSchemaInternal;
+
     if (_depth >= maxDepth) {
       throw new Error(
         `Maximum recursion depth (${maxDepth}) exceeded in collectIds. ` +
@@ -126,7 +128,7 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
 
     let addedScope = false;
 
-    const nodeId = getId(node as JsonSchemaInternal);
+    const nodeId = getId(schemaNode);
     if (typeof nodeId === 'string') {
       let type: Id['type'] = isAbsoluteUri(nodeId) ? 'absolute' : 'relative';
       if (scope.length === 0) {
@@ -135,17 +137,17 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
       const id: Id = {
         id: nodeId,
         type,
-        obj: node as JsonSchemaInternal,
+        obj: schemaNode,
       };
       if (type === 'absolute' || (type === 'root' && isAbsoluteUri(nodeId))) {
         id.absoluteUri = nodeId;
       } else if (
         type === 'root' &&
-        typeof node.id === 'string' &&
-        isAbsoluteUri(node.id as string) &&
-        node.id !== nodeId
+        typeof schemaNode.id === 'string' &&
+        isAbsoluteUri(schemaNode.id) &&
+        schemaNode.id !== nodeId
       ) {
-        id.absoluteUri = resolveSchemaScopeId(node.id as string, node as JsonSchemaInternal, nodeId);
+        id.absoluteUri = resolveSchemaScopeId(schemaNode.id, schemaNode, nodeId);
       } else if (type === 'relative') {
         let absoluteParent: Id | undefined;
         for (let i = scope.length - 1; i >= 0; i--) {
@@ -158,7 +160,7 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
         id.absoluteParent = absoluteParent;
         if (id.absoluteParent) {
           const parentUri = id.absoluteParent.absoluteUri || id.absoluteParent.id;
-          id.absoluteUri = resolveSchemaScopeId(parentUri, node as JsonSchemaInternal, id.id);
+          id.absoluteUri = resolveSchemaScopeId(parentUri, schemaNode, id.id);
         }
       }
       ids.push(id);
@@ -171,11 +173,11 @@ export const collectIds = (obj: JsonSchemaInternal, maxDepth = DEFAULT_MAX_RECUR
         walk(item, scope, _depth + 1);
       }
     } else {
-      for (const key of Object.keys(node as object)) {
+      for (const key of Object.keys(schemaNode)) {
         if (isInternalKey(key) || NON_SCHEMA_KEYWORDS_SET.has(key)) {
           continue;
         }
-        walk(node[key], scope, _depth + 1);
+        walk((schemaNode as Record<string, unknown>)[key], scope, _depth + 1);
       }
     }
 

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -1,7 +1,7 @@
 export function copyProp(from: object, to: object, key: string | number | symbol, fn?: (value: unknown) => unknown) {
   if (Object.hasOwn(from, key)) {
     Object.defineProperty(to, key, {
-      value: fn ? fn((from as any)[key]) : (from as any)[key],
+      value: fn ? fn((from as Record<PropertyKey, unknown>)[key]) : (from as Record<PropertyKey, unknown>)[key],
       enumerable: true,
       writable: true,
       configurable: true,

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -314,8 +314,7 @@ export class ZSchemaBase {
     const visited = new WeakSet<object>();
 
     // clean-up the schema and resolve references
-    const cleanup = (node: any) => {
-      let key;
+    const cleanup = (node: unknown) => {
       const typeOf = whatIs(node);
       if (typeOf !== 'object' && typeOf !== 'array') {
         return;
@@ -327,23 +326,25 @@ export class ZSchemaBase {
 
       visited.add(node as object);
 
-      if (node.$ref && node.__$refResolved) {
-        const from = node.__$refResolved as JsonSchemaInternal;
-        const to = node as JsonSchemaInternal;
-        delete node.$ref;
-        delete node.__$refResolved;
-        for (key in from) {
+      const schemaNode = node as JsonSchemaInternal;
+      if (schemaNode.$ref && schemaNode.__$refResolved) {
+        const from = schemaNode.__$refResolved as JsonSchemaInternal;
+        const to = schemaNode;
+        delete schemaNode.$ref;
+        delete schemaNode.__$refResolved;
+        for (const key in from) {
           if (Object.hasOwn(from, key)) {
             copyProp(from, to, key);
           }
         }
       }
-      for (key in node) {
-        if (Object.hasOwn(node as object, key)) {
+      const record = node as Record<string, unknown>;
+      for (const key in record) {
+        if (Object.hasOwn(record, key)) {
           if (isInternalKey(key)) {
-            delete node[key];
+            delete record[key];
           } else {
-            cleanup(node[key]);
+            cleanup(record[key]);
           }
         }
       }

--- a/src/z-schema-options.ts
+++ b/src/z-schema-options.ts
@@ -112,7 +112,7 @@ export const normalizeOptions = (options?: ZSchemaOptions) => {
     keys = Object.keys(defaultOptions) as Array<keyof ZSchemaOptions>;
     for (const key of keys) {
       if (options[key] === undefined) {
-        (options as any)[key] = shallowClone(defaultOptions[key]);
+        (options as Record<string, unknown>)[key] = shallowClone(defaultOptions[key]);
       }
     }
 


### PR DESCRIPTION
## What

Enables `typescript/no-unsafe-member-access` (removed from the TODO backlog). The 15 `src/` sites are fixed by routing the `any`-typed schema traversals through **typed views** instead of accessing properties on `any`.

- **[schema-compiler.ts](src/schema-compiler.ts)** `collectIds.walk`: introduce `const schemaNode = node as JsonSchemaInternal` after the object guard; `.id` / `getId` / `Object.keys` go through it, children index via `(schemaNode as Record<string, unknown>)[key]`. **This also lets the PR #436 `node.id as string` casts be dropped** (narrowing now works on the typed `schemaNode.id`), so net casts *decrease*.
- **[z-schema-base.ts](src/z-schema-base.ts)** cleanup closure: param `any` → `unknown`; named fields via `schemaNode = node as JsonSchemaInternal` (`.$ref`/`.__$refResolved`), dynamic keys via `record = node as Record<string, unknown>`. Same object reference; identical deletes/recursion.
- **[properties.ts](src/utils/properties.ts)**: `(from as any)[key]` → `(from as Record<PropertyKey, unknown>)[key]`.
- **[z-schema-options.ts](src/z-schema-options.ts)**: `(options as any)[key] = …` → `(options as Record<string, unknown>)[key] = …`.

Remaining `as JsonSchemaInternal` / `as Record` / `as object` casts are type-only and will be reviewed under `no-unsafe-type-assertion` (PR 8 — the final one). Legacy `test/` fixtures (105 sites) suppressed via the existing `test/**` override.

## Verification

- `npx oxlint --type-aware` → clean (exit 0); `no-unsafe-member-access` count in `src/` = 0.
- `tsc --noEmit` (src) → clean. `npm run build` + `npm run build:tests` → pass.
- `npm test` → **32389 passed**.
- Public `.d.ts` diff vs `main` → **identical**.