### PR TITLE
refactor: internal schema-type view; reclassify no-unsafe-type-assertion

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ Line coverage status: **high**
 | src/json-schema-versions.ts   |    100% |        100% |       100% |     100% |
 | src/json-schema.ts            |     98% |         98% |       100% |      98% |
 | src/json-validation.ts        |     91% |         91% |       100% |      89% |
-| src/report.ts                 |     94% |         94% |        95% |      88% |
+| src/report.ts                 |     93% |         94% |        95% |      87% |
 | src/schema-cache.ts           |     90% |         90% |        92% |      89% |
 | src/schema-compiler.ts        |     94% |         93% |       100% |      90% |
 | src/schema-validator.ts       |     79% |         79% |       100% |      76% |

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -41,6 +41,15 @@ export default defineConfig({
     'typescript/no-dynamic-delete': 'off',
     'typescript/no-explicit-any': 'off',
     'typescript/no-non-null-assertion': 'off',
+    // Kept off intentionally (not a TODO): the internal schema-type view
+    // (JsonSchemaInternal re-typing every sub-schema keyword) removed the
+    // public↔internal bridge casts, but the remaining assertions are
+    // irreducible — untrusted `JSON.parse`/`Object.create(null)` results,
+    // generic deep-clone (`res as T`/`as U`), the `Object.keys(x) as (keyof X)[]`
+    // idiom, prototype-pollution guards, unknown-tree traversal, and error-path
+    // `error as ValidateError`. None have a type-guard equivalent, so the rule
+    // stays off rather than scattering ~60 inline disables across the codebase.
+    'typescript/no-unsafe-type-assertion': 'off',
     'typescript/prefer-nullish-coalescing': 'off',
     'typescript/promise-function-async': 'off',
     'typescript/strict-boolean-expressions': 'off',
@@ -77,17 +86,6 @@ export default defineConfig({
     // hot path (utils/clone.ts shallowClone/deepClone key ordering). Enabling the
     // rule would force a per-comparison JS callback for no functional gain.
     'unicorn/no-array-sort': 'off',
-
-    // ── TODO: rules from the ultracite preset currently reporting errors ──
-    // Disabled to reach a clean baseline; re-evaluate and re-enable incrementally.
-
-    // TODO: evaluate this rule in the future
-    // occurrences in codebase: 23
-    // complexity: dangerous
-    // Most sites assert values to `any` or narrow types; tightening requires real upstream typing work.
-    // type: type-safety
-    // Flags type assertions that bypass the type checker (notably assertions to/from `any`), which can mask runtime errors.
-    'typescript/no-unsafe-type-assertion': 'off',
   },
   overrides: [
     {

--- a/src/json-schema-versions.ts
+++ b/src/json-schema-versions.ts
@@ -76,10 +76,64 @@ export interface JsonSchemaAll extends JsonSchemaCommon {
 // ---------------------------------------------------------------------------
 
 /**
- * Internal schema type used throughout the validator. Based on `JsonSchemaAll`
- * so that validators can access any draft-specific property without narrowing.
+ * Sub-schema-valued keywords. On the internal type these point at
+ * `JsonSchemaInternal` (rather than the public `JsonSchema`) so the validator
+ * can traverse nested schemas without asserting `as JsonSchemaInternal` at
+ * every step.
  */
-export type JsonSchemaInternal = JsonSchemaAll & ZSchemaInternalProperties;
+type InternalSchemaKeys =
+  | 'items'
+  | 'additionalItems'
+  | 'properties'
+  | 'patternProperties'
+  | 'additionalProperties'
+  | 'dependencies'
+  | 'allOf'
+  | 'anyOf'
+  | 'oneOf'
+  | 'not'
+  | 'definitions'
+  | 'contains'
+  | 'propertyNames'
+  | 'if'
+  | 'then'
+  | 'else'
+  | '$defs'
+  | 'dependentSchemas'
+  | 'unevaluatedItems'
+  | 'unevaluatedProperties'
+  | 'prefixItems';
+
+/**
+ * Internal schema type used throughout the validator. Based on `JsonSchemaAll`
+ * so that validators can access any draft-specific property without narrowing,
+ * but with every sub-schema keyword re-typed to `JsonSchemaInternal` so nested
+ * traversal needs no type assertions.
+ */
+export type JsonSchemaInternal = Omit<JsonSchemaAll, InternalSchemaKeys> &
+  ZSchemaInternalProperties & {
+    items?: JsonSchemaInternal | boolean | Array<JsonSchemaInternal | boolean>;
+    additionalItems?: boolean | JsonSchemaInternal;
+    properties?: Record<string, JsonSchemaInternal | boolean>;
+    patternProperties?: Record<string, JsonSchemaInternal>;
+    additionalProperties?: boolean | JsonSchemaInternal;
+    dependencies?: Record<string, string[] | JsonSchemaInternal>;
+    allOf?: JsonSchemaInternal[];
+    anyOf?: JsonSchemaInternal[];
+    oneOf?: JsonSchemaInternal[];
+    not?: JsonSchemaInternal;
+    definitions?: Record<string, JsonSchemaInternal>;
+    contains?: JsonSchemaInternal;
+    propertyNames?: JsonSchemaInternal;
+    if?: JsonSchemaInternal | boolean;
+    then?: JsonSchemaInternal | boolean;
+    else?: JsonSchemaInternal | boolean;
+    $defs?: Record<string, JsonSchemaInternal>;
+    dependentSchemas?: Record<string, JsonSchemaInternal>;
+    unevaluatedItems?: JsonSchemaInternal | boolean;
+    unevaluatedProperties?: JsonSchemaInternal | boolean;
+    prefixItems?: Array<JsonSchemaInternal | boolean>;
+  };
 
 /** @deprecated Use `JsonSchemaInternal` — they are now equivalent. */
 export type JsonSchemaInternalAll = JsonSchemaAll & ZSchemaInternalProperties;

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -79,9 +79,9 @@ export type JsonSchemaType = 'array' | 'boolean' | 'integer' | 'null' | 'number'
 export interface ZSchemaInternalProperties {
   __$compiled?: unknown;
   __$missingReferences?: Reference[];
-  __$refResolved?: JsonSchema;
-  __$dynamicRefResolved?: JsonSchema;
-  __$recursiveRefResolved?: JsonSchema;
+  __$refResolved?: JsonSchemaInternal;
+  __$dynamicRefResolved?: JsonSchemaInternal;
+  __$recursiveRefResolved?: JsonSchemaInternal;
   __$resourceRoot?: JsonSchemaInternal;
   __$schemaResolved?: unknown;
   __$validated?: boolean;

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -307,17 +307,17 @@ function collectEvaluated(ctx: ZSchemaBase, args: CollectEvaluatedArgs): Set<num
     let condPassed = getCachedValidationResult(report, currentSchema.if, json);
     if (condPassed === undefined) {
       const condReport = new Report(report);
-      validate(ctx, condReport, currentSchema.if as JsonSchemaInternal | boolean, json);
+      validate(ctx, condReport, currentSchema.if, json);
       condPassed = condReport.errors.length === 0;
     }
     if (condPassed) {
-      if (merge(recurse(currentSchema.if as JsonSchemaInternal | boolean))) {
+      if (merge(recurse(currentSchema.if))) {
         return 'all';
       }
-      if (currentSchema.then !== undefined && merge(recurse(currentSchema.then as JsonSchemaInternal | boolean))) {
+      if (currentSchema.then !== undefined && merge(recurse(currentSchema.then))) {
         return 'all';
       }
-    } else if (currentSchema.else !== undefined && merge(recurse(currentSchema.else as JsonSchemaInternal | boolean))) {
+    } else if (currentSchema.else !== undefined && merge(recurse(currentSchema.else))) {
       return 'all';
     }
   }
@@ -326,7 +326,7 @@ function collectEvaluated(ctx: ZSchemaBase, args: CollectEvaluatedArgs): Set<num
   if (
     currentSchema.__$refResolved &&
     currentSchema.__$refResolved !== currentSchema &&
-    merge(recurse(currentSchema.__$refResolved as JsonSchemaInternal))
+    merge(recurse(currentSchema.__$refResolved))
   ) {
     return 'all';
   }
@@ -400,7 +400,7 @@ function unevaluatedItemsValidator(ctx: ZSchemaBase, report: Report, schema: Jso
     for (let i = 0; i < unevaluatedIndices.length; i++) {
       const idx = unevaluatedIndices[i];
       const subReport = new Report(report);
-      validate(ctx, subReport, unevalSchema as JsonSchemaInternal, json[idx]);
+      validate(ctx, subReport, unevalSchema, json[idx]);
       if (subReport.errors.length > 0) {
         report.addError('ARRAY_UNEVALUATED_ITEMS', undefined, undefined, schema, 'unevaluatedItems');
         break;
@@ -471,7 +471,7 @@ function unevaluatedPropertiesValidator(ctx: ZSchemaBase, report: Report, schema
     for (let i = 0; i < unevaluatedKeys.length; i++) {
       const key = unevaluatedKeys[i];
       const subReport = new Report(report);
-      validate(ctx, subReport, unevalSchema as JsonSchemaInternal, (json as Record<string, unknown>)[key]);
+      validate(ctx, subReport, unevalSchema, (json as Record<string, unknown>)[key]);
       if (subReport.errors.length > 0) {
         report.addError('OBJECT_UNEVALUATED_PROPERTIES', [key], undefined, schema, 'unevaluatedProperties');
       }
@@ -782,7 +782,7 @@ export function validate(
 
     if (applySiblingKeywordsWithRef) {
       if (schema.__$refResolved) {
-        validate(ctx, report, schema.__$refResolved as JsonSchemaInternal, json);
+        validate(ctx, report, schema.__$refResolved, json);
       } else {
         report.addError('REF_UNRESOLVED', [schema.$ref], undefined, schema);
       }

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -159,7 +159,7 @@ const SchemaValidators = {
       }
     } else if (isObject(schema.items) || (report.options.version !== 'draft-04' && typeof schema.items === 'boolean')) {
       report.path.push('items');
-      this.validateSchema(report, schema.items as JsonSchemaInternal);
+      this.validateSchema(report, schema.items);
       report.path.pop();
     } else {
       report.addError(
@@ -544,7 +544,7 @@ const SchemaValidators = {
       return;
     }
     report.path.push('not');
-    this.validateSchema(report, notSchema as JsonSchemaInternal);
+    this.validateSchema(report, notSchema!);
     report.path.pop();
   },
   if(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
@@ -560,7 +560,7 @@ const SchemaValidators = {
     }
 
     report.path.push('if');
-    this.validateSchema(report, ifSchema as JsonSchemaInternal);
+    this.validateSchema(report, ifSchema);
     report.path.pop();
   },
   then(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
@@ -576,7 +576,7 @@ const SchemaValidators = {
     }
 
     report.path.push('then');
-    this.validateSchema(report, thenSchema as JsonSchemaInternal);
+    this.validateSchema(report, thenSchema);
     report.path.pop();
   },
   else(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
@@ -592,7 +592,7 @@ const SchemaValidators = {
     }
 
     report.path.push('else');
-    this.validateSchema(report, elseSchema as JsonSchemaInternal);
+    this.validateSchema(report, elseSchema);
     report.path.pop();
   },
   definitions(this: SchemaValidator, report: Report, schema: JsonSchemaInternal) {
@@ -626,7 +626,7 @@ const SchemaValidators = {
       const val = schema.$defs[key];
       report.path.push('$defs');
       report.path.push(key);
-      this.validateSchema(report, val as JsonSchemaInternal);
+      this.validateSchema(report, val);
       report.path.pop();
       report.path.pop();
     }

--- a/src/validation/array.ts
+++ b/src/validation/array.ts
@@ -118,7 +118,7 @@ export function containsValidator(ctx: ZSchemaBase, report: Report, schema: Json
   for (let idx = 0; idx < json.length; idx++) {
     const subReport = new Report_(report);
     subReports.push(subReport);
-    ctx._jsonValidate(subReport, containsSchema as JsonSchemaInternal, json[idx]);
+    ctx._jsonValidate(subReport, containsSchema, json[idx]);
     cacheValidationResult(report, containsSchema, json[idx], subReport.errors.length === 0);
   }
 

--- a/src/validation/combinators.ts
+++ b/src/validation/combinators.ts
@@ -111,7 +111,7 @@ export function ifValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchema
   }
 
   const conditionReport = new Report(report);
-  ctx._jsonValidate(conditionReport, conditionSchema as JsonSchemaInternal, json);
+  ctx._jsonValidate(conditionReport, conditionSchema, json);
   cacheValidationResult(report, conditionSchema, json, conditionReport.errors.length === 0);
 
   const branchSchema = conditionReport.errors.length === 0 ? thenSchema : elseSchema;
@@ -119,7 +119,7 @@ export function ifValidator(ctx: ZSchemaBase, report: Report, schema: JsonSchema
     return;
   }
 
-  ctx._jsonValidate(report, branchSchema as JsonSchemaInternal, json);
+  ctx._jsonValidate(report, branchSchema, json);
 }
 
 export function thenValidator() {

--- a/src/validation/object.ts
+++ b/src/validation/object.ts
@@ -298,7 +298,7 @@ export function propertyNamesValidator(ctx: ZSchemaBase, report: Report, schema:
   for (const key of keys) {
     const subReport = new Report_(report);
     subReports.push(subReport);
-    ctx._jsonValidate(subReport, propertyNamesSchema as JsonSchemaInternal, key);
+    ctx._jsonValidate(subReport, propertyNamesSchema, key);
   }
 
   const addPropertyNameErrors = () => {

--- a/src/validation/ref.ts
+++ b/src/validation/ref.ts
@@ -39,7 +39,7 @@ export const resolveRecursiveRef = (
   schema: JsonSchemaInternal,
   recursiveAnchorStack: JsonSchemaInternal[]
 ): JsonSchemaInternal | undefined => {
-  const resolved = schema.__$recursiveRefResolved as JsonSchemaInternal | undefined;
+  const resolved = schema.__$recursiveRefResolved;
   if (!resolved) {
     return undefined;
   }

--- a/src/z-schema-base.ts
+++ b/src/z-schema-base.ts
@@ -328,7 +328,7 @@ export class ZSchemaBase {
 
       const schemaNode = node as JsonSchemaInternal;
       if (schemaNode.$ref && schemaNode.__$refResolved) {
-        const from = schemaNode.__$refResolved as JsonSchemaInternal;
+        const from = schemaNode.__$refResolved;
         const to = schemaNode;
         delete schemaNode.$ref;
         delete schemaNode.__$refResolved;


### PR DESCRIPTION
## What

The **final** rule in the oxlint TODO backlog. Handled in two parts:

### 1. Internal schema-type view (refactor)
`JsonSchemaInternal` now re-types every sub-schema keyword (`items`, `contains`, `if`/`then`/`else`, `allOf`, `properties`, `$defs`, `dependentSchemas`, `unevaluated*`, `prefixItems`, …) and the `__$refResolved`/`__$dynamicRefResolved`/`__$recursiveRefResolved` fields to `JsonSchemaInternal` instead of the public `JsonSchema`. This lets the validator traverse nested schemas **without** asserting `as JsonSchemaInternal`, and ~20 now-redundant casts were removed across json-validation, schema-validator, combinators, object, ref, and z-schema-base (mostly via the `no-unnecessary-type-assertion` autofix).

### 2. Reclassify `typescript/no-unsafe-type-assertion` as intentional-off
After the refactor, the ~69 remaining assertions are **irreducible** — untrusted `JSON.parse`/`Object.create(null)`, generic deep-clone (`res as T`/`as U`), the `Object.keys(x) as (keyof X)[]` idiom, prototype-pollution guards, unknown-tree traversal, and error-path `error as ValidateError`. None have a type-guard equivalent; enabling would require **~60 inline disables** — worse signal than one documented intentional-off entry. Matches the reclassify precedent (#426/#428/#429/#431).

This **completes the TODO backlog**: all 8 rules are now either enabled (#432–#437) or intentional-off with rationale (#431 + this).

## Public API note
`JsonSchemaInternal` is reachable via the exported `Report` type, so `Report.rootSchema`'s sub-schema fields are now typed `JsonSchemaInternal` (a deliberate, accepted refinement). `JsonSchema` / `JsonSchemaCommon` / draft interfaces / `ValidateOptions` / `ZSchemaOptions` are unchanged.

## Verification

- `npx oxlint --type-aware` → clean (exit 0).
- `tsc --noEmit` (src) → 0 errors. `npm run build` + `npm run build:tests` → pass.
- `npm test` → **32389 passed**.
- Behavior-preserving (type-only changes throughout).