### PR TITLE
ci: run copy:schemas before check in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,6 +43,13 @@ jobs:
       - run: npx playwright install --with-deps
         if: ${{ steps.release.outputs.release_created }}
 
+      # Generates src/schemas/*.json from the json-schema-spec submodule.
+      # Required before `check`: the type-aware lint resolves the JSON imports
+      # in z-schema-versions.ts, which are absent on a fresh checkout until the
+      # build's copy:schemas step runs.
+      - run: npm run copy:schemas
+        if: ${{ steps.release.outputs.release_created }}
+
       - run: npm run check
         if: ${{ steps.release.outputs.release_created }}
 


### PR DESCRIPTION
## Why

The Release Please workflow failed on `npm run check` ([run 26913440809](https://github.com/zaggino/z-schema/actions/runs/26913440809)) with 19 `typescript/no-unsafe-assignment` errors in `src/z-schema-versions.ts`:

> Unsafe assignment of an error typed value.

### Root cause

`npm run check` runs the type-aware oxlint pass, which resolves the bundled JSON schema imports in `z-schema-versions.ts`. Those `src/schemas/*.json` files are gitignored and generated by `npm run copy:schemas` (part of the build). On a fresh CI checkout they don't exist, so the imports resolve to the `error` type — and the recently enabled `typescript/no-unsafe-assignment` rule (#435) flags every assignment.

`build-and-test.yml` already guards against this by running `copy:schemas` before `check`; `release-please.yml` did not.

## Fix

Add the `copy:schemas` step before `check` in `release-please.yml`, mirroring `build-and-test.yml` (comment included).