### PR TITLE
test: scale async test-suite timeout to configured asyncTimeout

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ Line coverage status: **high**
 | src/json-schema-versions.ts   |    100% |        100% |       100% |     100% |
 | src/json-schema.ts            |     98% |         98% |       100% |      98% |
 | src/json-validation.ts        |     91% |         91% |       100% |      89% |
-| src/report.ts                 |     93% |         94% |        95% |      87% |
+| src/report.ts                 |     94% |         94% |        95% |      88% |
 | src/schema-cache.ts           |     90% |         90% |        92% |      89% |
 | src/schema-compiler.ts        |     94% |         93% |       100% |      90% |
 | src/schema-validator.ts       |     79% |         79% |       100% |      76% |

--- a/test/spec/z-schema-test-suite.spec.ts
+++ b/test/spec/z-schema-test-suite.spec.ts
@@ -142,80 +142,90 @@ describe('ZSchemaTestSuite', () => {
         options.version = version;
       }
 
-      it(`${testSuite.description}, ${test.description}`, async () => {
-        if (async) {
+      // Async tests may intentionally block until `asyncTimeout` elapses (e.g. the
+      // ASYNC_TIMEOUT case). Under browser + coverage instrumentation that timer plus
+      // overhead can exceed a flat 1s budget, so scale the per-test timeout to the
+      // configured asyncTimeout (defaulting to 2000ms) with generous headroom.
+      const testTimeout = async ? (options.asyncTimeout ?? 2000) + 5000 : 1000;
+
+      it(
+        `${testSuite.description}, ${test.description}`,
+        async () => {
+          if (async) {
+            const validator = ZSchema.create(options);
+            if (setup) {
+              setup(validator, ZSchema);
+            }
+
+            if (Array.isArray(schema)) {
+              schema = schema[schemaIndex];
+            }
+
+            const response = await validator.validateAsyncSafe(data, schema as any, validateOptions as any);
+            const { valid, err } = response;
+
+            expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
+            expect(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
+            if (test.valid) {
+              expect(err).toBe(undefined /*, 'errors are not undefined when test is valid'*/);
+            }
+            if (after) {
+              after(err?.details ?? err ?? undefined, valid, data, validator);
+            }
+            return;
+          }
+
+          ZSchema.setSchemaReader(undefined);
+
           const validator = ZSchema.create(options);
+          let caughtErr;
+
           if (setup) {
             setup(validator, ZSchema);
           }
 
-          if (Array.isArray(schema)) {
-            schema = schema[schemaIndex];
-          }
-
-          const response = await validator.validateAsyncSafe(data, schema as any, validateOptions as any);
-          const { valid, err } = response;
-
-          expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
-          expect(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
-          if (test.valid) {
-            expect(err).toBe(undefined /*, 'errors are not undefined when test is valid'*/);
-          }
-          if (after) {
-            after(err?.details ?? err ?? undefined, valid, data, validator);
-          }
-          return;
-        }
-
-        ZSchema.setSchemaReader(undefined);
-
-        const validator = ZSchema.create(options);
-        let caughtErr;
-
-        if (setup) {
-          setup(validator, ZSchema);
-        }
-
-        let valid: boolean | undefined;
-        try {
-          validator.validateSchema(schema as any);
-          valid = true;
-        } catch (error) {
-          if (!failWithException) {
-            valid = false;
-          }
-          caughtErr = error;
-        }
-
-        if (valid && !validateSchemaOnly) {
-          if (Array.isArray(schema)) {
-            schema = schema[schemaIndex];
-          }
+          let valid: boolean | undefined;
           try {
-            valid = validator.validate(data, schema as any, validateOptions as any);
+            validator.validateSchema(schema as any);
+            valid = true;
           } catch (error) {
-            valid = false;
+            if (!failWithException) {
+              valid = false;
+            }
             caughtErr = error;
           }
-        }
 
-        const err = caughtErr as ValidateError | undefined;
+          if (valid && !validateSchemaOnly) {
+            if (Array.isArray(schema)) {
+              schema = schema[schemaIndex];
+            }
+            try {
+              valid = validator.validate(data, schema as any, validateOptions as any);
+            } catch (error) {
+              valid = false;
+              caughtErr = error;
+            }
+          }
 
-        if (failWithException) {
-          expect(caughtErr).toBeTruthy();
-        } else {
-          expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
-          expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
-        }
+          const err = caughtErr as ValidateError | undefined;
 
-        if (test.valid) {
-          expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
-        }
+          if (failWithException) {
+            expect(caughtErr).toBeTruthy();
+          } else {
+            expect(typeof valid).toBe('boolean' /*, 'returned response is not a boolean'*/);
+            expect.soft(valid).toBe(test.valid /*, "test result doesn't match expected test result"*/);
+          }
 
-        if (after) {
-          after(err?.details ?? err ?? undefined, valid!, data, validator);
-        }
-      }, 1000);
+          if (test.valid) {
+            expect(err).toBeFalsy(/*, 'errors are not undefined when test is valid'*/);
+          }
+
+          if (after) {
+            after(err?.details ?? err ?? undefined, valid!, data, validator);
+          }
+        },
+        testTimeout
+      );
     });
   });
 });


### PR DESCRIPTION
## Why

[Build and test run 26913815607](https://github.com/zaggino/z-schema/actions/runs/26913815607/job/79398512058) failed in the **WebKit** browser project under coverage:

> Error: Test timed out in 1000ms.
> ❯ test/spec/z-schema-test-suite.spec.ts:145

### Root cause

Every test-suite case was given a hardcoded **1000ms** vitest per-test timeout. The case `registerFormat - Custom formats async support, should timeout if callback is not called in default limit` registers a format that never calls its callback, so validation deliberately blocks for the configured `asyncTimeout: 500ms` before emitting `ASYNC_TIMEOUT`.

- Node / Chromium / Firefox: ~520ms — under budget.
- WebKit + istanbul coverage: the 500ms timer + instrumentation overhead exceeded the 1000ms ceiling → flaky timeout failure.

The 500ms-wait-under-1000ms-budget margin is too thin once coverage instrumentation slows WebKit down. (`Issue209` even configures `asyncTimeout: 2000`, which would breach a flat 1000ms ceiling outright if any of its cases hit the timeout.)

## Fix

Scale the per-test timeout to the test's configured `asyncTimeout` (default 2000ms) plus 5000ms headroom for async tests; keep the strict 1000ms budget for sync tests. The timeout is a maximum, not a fixed wait, so fast tests are unaffected.

Verified `npm run check` passes and the affected async cases pass on the node project. (The formatter reflowed the `it(...)` call across lines — no behavioral change.)