### PR TITLE
fix(compiler): address review findings C1/I1/I2 + add coverage (I3)

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -8,6 +8,8 @@ When true, `ZSchema.create()` returns an async validator (`ZSchemaAsync` or `ZSc
 
 Also used by `ZSchemaCompiler` to determine whether `compile()` returns an async validation function.
 
+`async` and `safe` are dispatch-only flags: they select which validator variant `ZSchema.create()` returns and are **not** stored on the resulting instance's options.
+
 Default: `false`
 
 ```javascript

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -431,7 +431,7 @@ compiler.addSchema({ $id: 'person', type: 'object', required: ['name'] });
 compiler.validate({ name: 'Alice' }, 'person'); // returns true (throws on failure)
 ```
 
-`addSchema()` **requires** the schema to carry a `$id` (or `id` for draft-04) — that identifier is how `validate(data, ref)` finds it. The parameter type enforces this; passing a schema without one from untyped JavaScript still validates the schema but logs a `console.warn`, because it cannot be referenced afterwards.
+`addSchema()` **requires** the schema to carry a `$id` (or `id` for draft-04) — that identifier is how `validate(data, ref)` finds it. The parameter type enforces this; passing a schema without one from untyped JavaScript **throws**, because the schema could never be referenced afterwards.
 
 All other `ZSchemaOptions` (e.g., `version`, `breakOnFirstError`, `customFormats`) are forwarded to the internal validator.
 

--- a/src/z-schema-compiler.ts
+++ b/src/z-schema-compiler.ts
@@ -133,9 +133,8 @@ export class ZSchemaCompiler<T extends ZSchemaOptions = ZSchemaOptions> {
    *
    * A `$id` (or `id` for draft-04) is **required** to make the schema
    * referenceable — the parameter type enforces this. If a schema without one
-   * is passed at runtime (e.g. from untyped JavaScript), the call still
-   * validates the schema but emits a `console.warn`, since it cannot be
-   * referenced afterwards.
+   * is passed at runtime (e.g. from untyped JavaScript), the call throws,
+   * since the schema could never be referenced afterward.
    *
    * Like {@link compile}, this validates eagerly and throws on an invalid
    * schema **regardless of the `safe` option** — `safe` only affects data
@@ -147,9 +146,9 @@ export class ZSchemaCompiler<T extends ZSchemaOptions = ZSchemaOptions> {
    */
   addSchema(schema: JsonSchemaWithId): this {
     if (!getId(schema as JsonSchemaInternal)) {
-      console.warn(
-        'z-schema: addSchema() was called with a schema that has no $id (or id for draft-04); ' +
-          'it cannot be referenced via validate(data, ref).'
+      throw new Error(
+        'z-schema: addSchema() requires a schema with a $id (or id for draft-04); ' +
+          'without one it cannot be referenced via validate(data, ref).'
       );
     }
     this._zschema.validateSchema(schema);
@@ -184,6 +183,11 @@ export class ZSchemaCompiler<T extends ZSchemaOptions = ZSchemaOptions> {
     let resolvedSchema: JsonSchema;
     if (typeof schema === 'boolean') {
       resolvedSchema = schema ? ({} as JsonSchema) : ({ not: {} } as JsonSchema);
+      // Boolean schemas are valid by definition. Pre-mark the synthetic wrapper as
+      // validated so it short-circuits strict meta-validation (strictMode/noTypeless)
+      // — both the eager compile-time validateSchema and the data-path validateSchema
+      // honor __$validated. Only this fresh wrapper is mutated, never the caller's object.
+      (resolvedSchema as JsonSchemaInternal).__$validated = true;
     } else {
       resolvedSchema = schema;
     }

--- a/src/z-schema-options.ts
+++ b/src/z-schema-options.ts
@@ -42,9 +42,7 @@ export interface ZSchemaOptions {
   maxRecursionDepth?: number;
 }
 
-export const defaultOptions: Required<ZSchemaOptions> = {
-  async: false,
-  safe: false,
+export const defaultOptions: Required<Omit<ZSchemaOptions, 'async' | 'safe'>> = {
   // default version to validate against
   version: CURRENT_DEFAULT_SCHEMA_VERSION,
   // default timeout for all async tasks
@@ -111,8 +109,13 @@ export const normalizeOptions = (options?: ZSchemaOptions) => {
     let keys = Object.keys(options) as Array<keyof ZSchemaOptions>;
 
     // check that the options are correctly configured
+    const _defaults = defaultOptions as Record<string, unknown>;
     for (const key of keys) {
-      if (defaultOptions[key] === undefined) {
+      // async/safe are dispatch-only flags, stripped before normalizeOptions is called
+      if (key === 'async' || key === 'safe') {
+        continue;
+      }
+      if (_defaults[key] === undefined) {
         throw new Error(`Unexpected option passed to constructor: ${key}`);
       }
     }
@@ -121,7 +124,7 @@ export const normalizeOptions = (options?: ZSchemaOptions) => {
     keys = Object.keys(defaultOptions) as Array<keyof ZSchemaOptions>;
     for (const key of keys) {
       if (options[key] === undefined) {
-        (options as Record<string, unknown>)[key] = shallowClone(defaultOptions[key]);
+        (options as Record<string, unknown>)[key] = shallowClone(_defaults[key]);
       }
     }
 

--- a/src/z-schema.ts
+++ b/src/z-schema.ts
@@ -102,16 +102,24 @@ export class ZSchema extends ZSchemaBase {
   public static create(options: ZSchemaOptions & { safe: true }): ZSchemaSafe;
   public static create(options?: ZSchemaOptions): ZSchema;
   public static create(options: ZSchemaOptions = {}): ZSchema | ZSchemaSafe | ZSchemaAsync | ZSchemaAsyncSafe {
-    if (options.async && options.safe) {
-      return new ZSchemaAsyncSafe(options, FACTORY_TOKEN);
+    const isAsync = options.async;
+    const isSafe = options.safe;
+    // async/safe are dispatch-only flags — strip them onto a copy so they never
+    // reach (or get stored on) the validator instance, and the caller's object is
+    // left untouched.
+    const rest: ZSchemaOptions = { ...options };
+    delete rest.async;
+    delete rest.safe;
+    if (isAsync && isSafe) {
+      return new ZSchemaAsyncSafe(rest, FACTORY_TOKEN);
     }
-    if (options.async) {
-      return new ZSchemaAsync(options, FACTORY_TOKEN);
+    if (isAsync) {
+      return new ZSchemaAsync(rest, FACTORY_TOKEN);
     }
-    if (options.safe) {
-      return new ZSchemaSafe(options, FACTORY_TOKEN);
+    if (isSafe) {
+      return new ZSchemaSafe(rest, FACTORY_TOKEN);
     }
-    return new ZSchema(options, FACTORY_TOKEN);
+    return new ZSchema(rest, FACTORY_TOKEN);
   }
 
   /**

--- a/test/spec/lib-init-and-usage.spec.ts
+++ b/test/spec/lib-init-and-usage.spec.ts
@@ -60,4 +60,28 @@ describe('Initialization and usage', () => {
       valid: false,
     });
   });
+
+  it('Should not store the factory-only async/safe flags on the instance options', () => {
+    // async/safe are dispatch-only flags consumed by create(); they must not leak
+    // into the validator's stored options (nothing reads them post-dispatch).
+    const asyncSafe = ZSchema.create({ async: true, safe: true, version: 'none' }) as unknown as {
+      options: Record<string, unknown>;
+    };
+    expect('async' in asyncSafe.options).toBe(false);
+    expect('safe' in asyncSafe.options).toBe(false);
+
+    const safe = ZSchema.create({ safe: true, version: 'none' }) as unknown as { options: Record<string, unknown> };
+    expect('safe' in safe.options).toBe(false);
+
+    const plain = ZSchema.create({ version: 'none' }) as unknown as { options: Record<string, unknown> };
+    expect('async' in plain.options).toBe(false);
+    expect('safe' in plain.options).toBe(false);
+  });
+
+  it('Should not mutate the caller options object passed to create()', () => {
+    const opts = { async: true, safe: true, version: 'none' as const };
+    ZSchema.create(opts);
+    // create() strips async/safe onto a copy — the caller's object is untouched.
+    expect(opts).toEqual({ async: true, safe: true, version: 'none' });
+  });
 });

--- a/test/spec/z-schema-compiler.spec.ts
+++ b/test/spec/z-schema-compiler.spec.ts
@@ -145,6 +145,48 @@ describe('ZSchemaCompiler', () => {
     });
   });
 
+  describe('boolean schemas under strict options and real versions', () => {
+    // Regression: boolean schemas are valid JSON Schema, but the synthetic wrappers
+    // ({} for true, { not: {} } for false) used to fail strict meta-validation
+    // (KEYWORD_UNDEFINED_STRICT) and throw at compile time under strictMode/noTypeless.
+    it('should compile a true schema under strictMode (throw mode)', () => {
+      const compiler = new ZSchemaCompiler({ strictMode: true });
+      const validate = compiler.compile(true);
+      expect(validate('anything')).toBe(true);
+      expect(validate(42)).toBe(true);
+    });
+
+    it('should compile a false schema under strictMode (throw mode)', () => {
+      const compiler = new ZSchemaCompiler({ strictMode: true });
+      const validate = compiler.compile(false);
+      expect(() => validate('anything')).toThrow();
+    });
+
+    it('should compile boolean schemas under noTypeless', () => {
+      const compiler = new ZSchemaCompiler({ noTypeless: true });
+      expect(compiler.compile(true)('x')).toBe(true);
+      expect(() => compiler.compile(false)('x')).toThrow();
+    });
+
+    it('should compile boolean schemas under the default version (no version: none)', () => {
+      const compiler = new ZSchemaCompiler();
+      expect(compiler.compile(true)('x')).toBe(true);
+      expect(() => compiler.compile(false)('x')).toThrow();
+    });
+
+    it('should compile boolean schemas under strictMode in safe mode', () => {
+      const compiler = new ZSchemaCompiler({ strictMode: true, safe: true });
+      expect(compiler.compile(true)('x').valid).toBe(true);
+      expect(compiler.compile(false)('x').valid).toBe(false);
+    });
+
+    it('should compile boolean schemas under strictMode in async mode', async () => {
+      const compiler = new ZSchemaCompiler({ strictMode: true, async: true });
+      await expect(compiler.compile(true)('x')).resolves.toBe(true);
+      await expect(compiler.compile(false)('x')).rejects.toThrow();
+    });
+  });
+
   describe('schema pre-compilation', () => {
     it('should throw at compile time for invalid schemas', () => {
       const compiler = new ZSchemaCompiler();
@@ -306,15 +348,12 @@ describe('ZSchemaCompiler', () => {
       expect(() => compiler.addSchema({ type: 'not-a-valid-type', $id: 'bad' } as any)).toThrow();
     });
 
-    it('should warn when addSchema is called without a $id', () => {
+    it('should throw when addSchema is called without a $id', () => {
+      // A schema with no $id/id can never be referenced via validate(data, ref),
+      // so registering it is a no-op that looks successful — addSchema must throw
+      // rather than silently warn-and-continue.
       const compiler = new ZSchemaCompiler({ version: 'none' });
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      try {
-        compiler.addSchema({ type: 'string' } as any);
-        expect(warn).toHaveBeenCalledOnce();
-      } finally {
-        warn.mockRestore();
-      }
+      expect(() => compiler.addSchema({ type: 'string' } as any)).toThrow(/\$id/);
     });
 
     it('should throw for an unregistered ref (sync)', () => {
@@ -332,6 +371,54 @@ describe('ZSchemaCompiler', () => {
     it('should reject for an unregistered ref (async)', async () => {
       const compiler = new ZSchemaCompiler({ async: true, version: 'none' });
       await expect(compiler.validate({}, 'never-registered')).rejects.toThrow();
+    });
+
+    it('should report invalid for an unregistered ref (async + safe)', async () => {
+      const compiler = new ZSchemaCompiler({ async: true, safe: true, version: 'none' });
+      const result = await compiler.validate({}, 'never-registered');
+      expect(result.valid).toBe(false);
+      expect(result.err).toBeDefined();
+    });
+
+    it('should resolve a $ref from a compiled schema against a previously addSchema-d schema', () => {
+      const compiler = new ZSchemaCompiler({ version: 'none' });
+      compiler.addSchema({
+        $id: 'person',
+        type: 'object',
+        required: ['name'],
+        properties: { name: { type: 'string' } },
+      });
+      // A compiled schema referencing the addSchema-d schema by $ref must resolve
+      // through the shared instance cache.
+      const validate = compiler.compile({ $ref: 'person' });
+      expect(validate({ name: 'Alice' })).toBe(true);
+      expect(() => validate({})).toThrow();
+    });
+
+    it('should let an addSchema-d schema and a compiled schema with distinct ids coexist', () => {
+      const compiler = new ZSchemaCompiler({ version: 'none' });
+      compiler.addSchema({ $id: 'str', type: 'string' });
+      const validateNumber = compiler.compile({ $id: 'num', type: 'number' });
+
+      // The compiled function (keyed by a minted urn) and the addSchema-d ref each
+      // keep their own semantics — registering one does not disturb the other.
+      expect(validateNumber(42)).toBe(true);
+      expect(() => validateNumber('hello')).toThrow();
+      expect(compiler.validate('hello', 'str')).toBe(true);
+      expect(() => compiler.validate(42, 'str')).toThrow();
+    });
+
+    it('should register and validate a draft-04 schema by its id', () => {
+      const compiler = new ZSchemaCompiler({ version: 'draft-04' });
+      compiler.addSchema({
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        id: 'draft4-person',
+        type: 'object',
+        required: ['name'],
+        properties: { name: { type: 'string' } },
+      } as any);
+      expect(compiler.validate({ name: 'Alice' }, 'draft4-person')).toBe(true);
+      expect(() => compiler.validate({}, 'draft4-person')).toThrow();
     });
   });
 
@@ -363,6 +450,27 @@ describe('ZSchemaCompiler', () => {
       const validate = compiler.compile({ type: 'string', format: 'only-foo' });
       expect(validate('foo').valid).toBe(true);
       expect(validate('bar').valid).toBe(false);
+    });
+
+    it('should honor a custom format in throw mode', () => {
+      const compiler = new ZSchemaCompiler({
+        version: 'draft-04',
+        customFormats: { 'only-foo': (value: unknown) => value === 'foo' },
+      });
+      const validate = compiler.compile({ type: 'string', format: 'only-foo' });
+      expect(validate('foo')).toBe(true);
+      expect(() => validate('bar')).toThrow();
+    });
+
+    it('should honor a custom format in async mode', async () => {
+      const compiler = new ZSchemaCompiler({
+        async: true,
+        version: 'draft-04',
+        customFormats: { 'only-foo': (value: unknown) => value === 'foo' },
+      });
+      const validate = compiler.compile({ type: 'string', format: 'only-foo' });
+      await expect(validate('foo')).resolves.toBe(true);
+      await expect(validate('bar')).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
Follow-up fixes from the compiler-feature review, each TDD (failing test first, then fix). Base: `compiler`.

## C1 — boolean schemas throw under `strictMode` / `noTypeless`
`compile(true)` and `compile(false)` threw `SCHEMA_VALIDATION_FAILED` at compile time when the compiler was created with `{ strictMode: true }` or `{ noTypeless: true }`. The synthetic wrappers (`{}` for true, `{ not: {} }` for false) failed strict meta-validation (`KEYWORD_UNDEFINED_STRICT`). Existing boolean tests masked this with `version: 'none'`.

Fix: pre-mark the synthetic wrapper with `__$validated` so it short-circuits schema validation on both the compile-time (`_registerForCompile`) and data (`validateSchema`) paths. Boolean schemas are valid by definition; `deepClone` preserves the flag through `setRemoteReference`. Only the fresh wrapper is mutated — never the caller's object.

## I1 — `async`/`safe` leaked into instance options
`ZSchema.create()` read the dispatch flags but passed the same options object (flags intact) to the variant constructor, so they persisted in the instance's normalized options (a behavior change from the prior `delete`-based code). Fix: strip `async`/`safe` onto a copy in `create()` (caller object untouched) and drop them from `defaultOptions` (`Required<Omit<…>>`) so `normalizeOptions` no longer re-adds them.

## I2 — `addSchema()` silent failure
A schema with no `$id`/`id` produced a `console.warn` then a useless, unreferenceable registration that looked successful. Now throws, matching the parameter type's contract and the TSDoc.

## I3 — test coverage
Added: boolean schemas under strict options and real versions (the C1 regression); `addSchema` + `$ref` cross-reference; custom formats in throw + async modes; async+safe unregistered ref; draft-04 `id` registration; distinct-id coexistence of `addSchema`/`compile`.

## Verification
- `npm run test:node`: 8174 passing (63 in the two touched specs).
- `npm run build:tests` and `npm run check`: clean.
- Docs updated: `docs/usage.md` (addSchema now throws), `docs/options.md` (async/safe are dispatch-only, not stored).

## Note (not fixed — out of scope)
Same-$id across `addSchema` + `compile`: by-id lookup reflects the last registration (standard JSON Schema `$id` semantics); compiled functions stay isolated via their minted urn. The over-specified test was reframed to distinct-id coexistence.