### PR TITLE
ci: drop global npm@latest upgrade in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,9 +34,6 @@ jobs:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install -g npm@latest
-        if: ${{ steps.release.outputs.release_created }}
-
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
 


### PR DESCRIPTION
## Problem

The Release Please publish job [failed](https://github.com/zaggino/z-schema/actions/runs/29003585720/job/86069716546) with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
  .../npm/node_modules/libnpmpublish/lib/provenance.js:1
```

The workflow ran `npm install -g npm@latest`, which pulled **npm@12.0.0**. That build ships a broken `libnpmpublish`: `publish.js` requires `provenance.js`, whose first line is `require('sigstore')`, and `sigstore` is not bundled in the tarball. So `npm publish` crashes at module load — unconditionally, since we don't request provenance.

## Fix

Drop the `npm install -g npm@latest` step. `.nvmrc` is `lts/*`, and the LTS node installed by `setup-node` already bundles a working npm, so the global upgrade was both unnecessary and the source of the broken version.

## Note

12.4.0's release commit already landed on main, so the publish for it will still need a manual re-run of the job (or a local `npm publish`) once this merges.