### PR TITLE
chore(dependabot): ignore typescript semver-major until tsdown supports TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
       development:
         dependency-type: 'development'
         patterns: ['*']
+    ignore:
+      # tsdown's peer range still caps TypeScript at ^6; ignore the TS 7 major
+      # until tsdown widens it. Remove this once tsdown supports TypeScript 7.
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'gitsubmodule'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary

Adds a Dependabot ignore rule for the `typescript` **semver-major** update.

## Why

PR #462 (grouped dev-dependency bump) failed CI with a hard npm `ERESOLVE` peer conflict: it pulled `typescript 6.0.3 → 7.0.2`, but `tsdown@0.22.4` still declares `peerOptional typescript@"^5.0.0 || ^6.0.0"` and does not accept TS 7. That blocked the entire group even though the other 10 bumps were fine.

This rule lets Dependabot keep proposing TypeScript patch/minor updates and every other dependency, while holding back the TS 7 major until the toolchain supports it.

## Follow-up

Remove this ignore entry once `tsdown` widens its peer range to include TypeScript 7 (a comment in the file notes this).