### PR TITLE
fix(deps): bump postcss, nanoid and brace-expansion to patched releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2643,9 +2643,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4085,9 +4085,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4452,9 +4452,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4472,7 +4472,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Description

Bumps three vulnerable transitive dev dependencies to patched releases, taking `npm audit` from three findings to zero.

| Package | From | To | Advisory | Alert | Severity | Patched at | Chain |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `postcss` | 8.5.22 | 8.5.26 | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) | [#131](https://github.com/zaggino/z-schema/security/dependabot/131) **open** | moderate | 8.5.23 | `vitest → vite → postcss ^8.5.17` |
| `nanoid` | 3.3.16 | 3.3.18 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | #132 auto-dismissed | high | 3.3.17 | `vite → postcss → nanoid ^3.3.16` |
| `brace-expansion` | 5.0.8 | 5.0.9 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | #130 auto-dismissed | high | 5.0.9 | `rimraf → glob → minimatch → brace-expansion ^5.0.5` |

**All three are dev-scope and fully transitive — none reach the published package.**

- **`postcss`** — incomplete fix of `GHSA-6g55-p6wh-862q`: an attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset.
- **`nanoid`** — custom generators can loop indefinitely when `size` is zero.
- **`brace-expansion`** — DoS via unbounded intermediate arrays, bypassing the `CVE-2026-14257` mitigation. This advisory **supersedes** the 5.0.8 bump from d924e08, which was patched against the earlier `GHSA-3jxr-9vmj-r5cp` only.

### Why all three, when only #131 is open

Alerts #130 and #132 were auto-dismissed by a dev-scope rule, so they don't appear in the default alert view — but `npm audit` still reported them as two outstanding highs. Fixing all three costs a single command and no extra risk, so the audit lands at zero rather than at two known-vulnerable packages.

### Why the diff is lockfile-only

Every target version already satisfies the semver range its parent requests, so `package.json` needs no change and no new `overrides` entry is warranted — the existing `overrides` block keeps only `vite: ">=7.3.2"`. This follows the d924e08 precedent of bumping the lock and leaving the manifest alone.

The diff is three `version`/`resolved`/`integrity` triples. The only other line is `postcss` 8.5.26 tightening its own `nanoid` range from `^3.3.16` to `^3.3.17`, which is upstream package metadata. The root `packages[""]` block is untouched.

## Related issue

Closes Dependabot alert [#131](https://github.com/zaggino/z-schema/security/dependabot/131). Also clears the auto-dismissed #130 and #132.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Test improvement

## JSON Schema draft(s) affected

- [ ] draft-04
- [ ] draft-06
- [ ] draft-07
- [ ] draft-2019-09
- [ ] draft-2020-12
- [x] None / all drafts

## Checklist

- [x] Branch is based on `main`
- [x] Code follows the project's [conventions](docs/conventions.md)
- [x] `npm run check` passes (lint + format)
- [x] `npm run build` passes
- [x] `npm run build:tests` passes (test type-check)
- [x] `npm test` passes (node + browser)
- [x] New public types/values are exported through `src/index.ts` — n/a, no source change
- [x] New features have tests — n/a, no source change
- [x] `docs/` updated if the public API changed — n/a, the Documentation Policy triggers on options, error codes, exports, format validators and structural changes, none of which a dev-dependency lockfile bump touches
- [x] JSON Schema Test Suite entries un-excluded if applicable — n/a

## Test plan

| Gate | Result |
| --- | --- |
| `npm audit` | `found 0 vulnerabilities` (was 1 moderate + 2 high) |
| `npm run build` | pass — 69 files, ESM + CJS + UMD |
| `npm run build:tests` | pass |
| `npm test` | pass — **32833 tests across 102 files**, both `node` and `browser` projects |
| `npm run check` | pass — 201 files correctly formatted |
| `git diff -- package.json` | empty, as intended |

The `browser` project is the meaningful regression check here: it runs through Vitest/vite, which is exactly what pulls in `postcss` and `nanoid`.

## Additional notes

**`npm ci` could not be run locally** — it fails with `EPERM: operation not permitted, unlink` on `@oxlint/binding-win32-x64-msvc` and `@oxfmt/binding-win32-x64-msvc`. The cause is environmental and pre-existing, unrelated to this change: the VSCode oxlint/oxfmt language servers (`oxlint --lsp`, `oxfmt --lsp`) hold those native `.node` bindings open, and `npm ci` wipes `node_modules` before reinstalling. `npm install` was used instead and produced **no further lockfile drift**, which demonstrates the same `package.json` ↔ lockfile consistency. CI runs `npm ci` on this PR and is the authoritative check.

_Generated by [Claude Code](https://claude.ai/code)_
