### PR TITLE
fix(format): validate uri-template expression bodies per RFC 6570

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -7,7 +7,7 @@ Line coverage status: **high**
 | File                          |  Line % | Statement % | Function % | Branch % |
 | ----------------------------- | ------: | ----------: | ---------: | -------: |
 | src/errors.ts                 |    100% |        100% |       100% |     100% |
-| src/format-validators.ts      |     94% |         95% |        91% |      92% |
+| src/format-validators.ts      |     95% |         95% |        91% |      94% |
 | src/json-schema-versions.ts   |    100% |        100% |       100% |     100% |
 | src/json-schema.ts            |     98% |         98% |       100% |      98% |
 | src/json-validation.ts        |     91% |         91% |       100% |      89% |

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -280,8 +280,9 @@ const URI_TEMPLATE_VARSPEC_SRC = `${URI_TEMPLATE_VARNAME_SRC}(?::[1-9][0-9]{0,3}
 // RFC 6570 §2.2: operator = op-level2 ("+" / "#") / op-level3 ("." / "/" / ";" / "?" / "&")
 //                         / op-reserve ("=" / "," / "!" / "@" / "|")
 // op-reserve is accepted for ABNF fidelity only — the spec leaves its expansion semantics
-// undefined. "|" is unreachable in practice: the literal charset check in uriTemplateValidator
-// rejects any "|" anywhere in the input before this regex runs. Same for a bare space.
+// undefined. The "|" branch is unreachable in practice: the literal charset check in
+// uriTemplateValidator rejects any "|" anywhere in the input before this regex runs, and a
+// literal space is blocked by that same check.
 // RFC 6570 §2: expression body (braces excluded) = [ operator ] variable-list
 //              variable-list = varspec *( "," varspec )
 const URI_TEMPLATE_EXPRESSION_REGEX = new RegExp(
@@ -299,28 +300,29 @@ const uriTemplateValidator: FormatValidatorFn = (uri: unknown) => {
     return false;
   }
 
-  let inExpression = false;
-  let expressionStart = -1;
+  // A non-null expressionStart doubles as "inside an expression", so the slice below cannot
+  // read a stale index — the null check narrows it to a number.
+  let expressionStart: number | null = null;
   for (let idx = 0; idx < uri.length; idx++) {
     const ch = uri[idx];
     if (ch === '{') {
-      if (inExpression) {
+      if (expressionStart !== null) {
         return false;
       }
-      inExpression = true;
       expressionStart = idx + 1;
     } else if (ch === '}') {
-      if (!inExpression) {
+      if (expressionStart === null) {
         return false;
       }
       if (!URI_TEMPLATE_EXPRESSION_REGEX.test(uri.slice(expressionStart, idx))) {
         return false;
       }
-      inExpression = false;
+      expressionStart = null;
     }
   }
 
-  return !inExpression;
+  // An unterminated expression leaves expressionStart set.
+  return expressionStart === null;
 };
 
 const hasValidTildeEscapes = (segment: string): boolean => {

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -270,16 +270,37 @@ const uriReferenceValidator: FormatValidatorFn = (uri: unknown) => {
   return /^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?[^"\\<>^{}^`| ]*$/.test(uri);
 };
 
+// RFC 6570 §2.3: varchar = ALPHA / DIGIT / "_" / pct-encoded
+const URI_TEMPLATE_VARCHAR_SRC = '(?:[A-Za-z0-9_]|%[0-9A-Fa-f]{2})';
+// RFC 6570 §2.3: varname = varchar *( ["."] varchar )
+const URI_TEMPLATE_VARNAME_SRC = `${URI_TEMPLATE_VARCHAR_SRC}(?:\\.?${URI_TEMPLATE_VARCHAR_SRC})*`;
+// RFC 6570 §2.4: varspec = varname [ modifier-level4 ]; modifier-level4 = prefix / explode
+// prefix = ":" max-length, max-length = %x31-39 0*3DIGIT (1-9999, no leading zero); explode = "*"
+const URI_TEMPLATE_VARSPEC_SRC = `${URI_TEMPLATE_VARNAME_SRC}(?::[1-9][0-9]{0,3}|\\*)?`;
+// RFC 6570 §2.2: operator = op-level2 ("+" / "#") / op-level3 ("." / "/" / ";" / "?" / "&")
+//                         / op-reserve ("=" / "," / "!" / "@" / "|")
+// op-reserve is accepted for ABNF fidelity only — the spec leaves its expansion semantics
+// undefined. "|" is unreachable in practice: the literal charset check in uriTemplateValidator
+// rejects any "|" anywhere in the input before this regex runs. Same for a bare space.
+// RFC 6570 §2: expression body (braces excluded) = [ operator ] variable-list
+//              variable-list = varspec *( "," varspec )
+const URI_TEMPLATE_EXPRESSION_REGEX = new RegExp(
+  `^[+#./;?&=,!@|]?${URI_TEMPLATE_VARSPEC_SRC}(?:,${URI_TEMPLATE_VARSPEC_SRC})*$`
+);
+
 const uriTemplateValidator: FormatValidatorFn = (uri: unknown) => {
   if (typeof uri !== 'string') {
     return true;
   }
   // URI template allows braces for expressions.
+  // Literal text is checked leniently here: RFC 6570 also excludes "'" and bare "%" from
+  // literals, but tightening that would reject inputs accepted by earlier versions.
   if (!/^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?[^"\\<>^`| ]*$/.test(uri)) {
     return false;
   }
 
   let inExpression = false;
+  let expressionStart = -1;
   for (let idx = 0; idx < uri.length; idx++) {
     const ch = uri[idx];
     if (ch === '{') {
@@ -287,8 +308,12 @@ const uriTemplateValidator: FormatValidatorFn = (uri: unknown) => {
         return false;
       }
       inExpression = true;
+      expressionStart = idx + 1;
     } else if (ch === '}') {
       if (!inExpression) {
+        return false;
+      }
+      if (!URI_TEMPLATE_EXPRESSION_REGEX.test(uri.slice(expressionStart, idx))) {
         return false;
       }
       inExpression = false;

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -147,4 +147,67 @@ describe('Format Validators', () => {
       expect(validator.options.asyncTimeout).toBe(5000);
     });
   });
+
+  describe('URI Template Format Validator', () => {
+    const uriTemplateSchema = { type: 'string', format: 'uri-template' };
+
+    it.each([
+      // literals only
+      ['', 'empty string'],
+      ['foo', 'plain literal'],
+      ['a%41b', 'percent-encoded triplet in a literal'],
+      ['a\u{1F600}b', 'supplementary plane character in a literal'],
+      ['http://example.com/dictionary', 'absolute URI without expressions'],
+      // expressions
+      ['http://example.com/dictionary/{term:1}/{term}', 'absolute URI with expressions'],
+      ['dictionary/{term:1}/{term}', 'relative template with expressions'],
+      ['{var}', 'bare varspec'],
+      ['{+var}', 'reserved expansion operator'],
+      ['{#var*}', 'fragment operator with explode modifier'],
+      ['{.a}', 'label operator (op-level3), not a leading varname dot'],
+      ['{/a,b}', 'path-segment operator with a variable list'],
+      ['{;x,y}', 'path-style parameter operator'],
+      ['{?x,y}', 'form-style query operator'],
+      ['{&x}', 'form-style query continuation operator'],
+      ['{,var}', 'op-reserve operator accepted for ABNF fidelity'],
+      ['{a.b:3}', 'dotted varname with a prefix modifier'],
+      ['{%41var}', 'varname starting with a percent-encoded triplet'],
+      ['{v:1}', 'minimum prefix max-length'],
+      ['{v:9999}', 'maximum prefix max-length'],
+    ])('should accept %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, uriTemplateSchema).valid).toBe(true);
+    });
+
+    it.each([
+      // malformed expression bodies — the RFC 6570 §2 gap this block guards
+      ['{}', 'empty expression'],
+      ['{a,,b}', 'empty varspec inside the variable list'],
+      ['{v:0}', 'zero prefix max-length'],
+      ['{v:10000}', 'five-digit prefix max-length'],
+      ['{v:01}', 'leading zero in prefix max-length'],
+      ['{v:99999}', 'five-digit prefix max-length above the cap'],
+      ['{var:}', 'prefix modifier without a max-length'],
+      ['{*}', 'explode modifier without a varname'],
+      ['{:3}', 'prefix modifier without a varname'],
+      ['{a..b}', 'consecutive dots in a varname'],
+      ['{a.}', 'trailing dot in a varname'],
+      ['{a-b}', 'hyphen is not a varchar'],
+      // brace structure
+      ['{a{b}', 'nested opening brace'],
+      ['{a}}', 'trailing unmatched closing brace'],
+      ['}{', 'closing brace before an opening brace'],
+      ['foo}bar', 'unmatched closing brace in a literal'],
+      ['http://example.com/dictionary/{term:1}/{term', 'unterminated expression'],
+    ])('should reject %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, uriTemplateSchema).valid).toBe(false);
+    });
+
+    // Format validators apply to strings only; every other type is vacuously valid.
+    it.each([12, 13.7, {}, [], false, null])('should ignore non-string input %j', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, { format: 'uri-template' }).valid).toBe(true);
+    });
+  });
 });

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -158,6 +158,11 @@ describe('Format Validators', () => {
       ['a%41b', 'percent-encoded triplet in a literal'],
       ['a\u{1F600}b', 'supplementary plane character in a literal'],
       ['http://example.com/dictionary', 'absolute URI without expressions'],
+      // Literal text is validated leniently on purpose: RFC 6570 excludes bare "%" and "'"
+      // from literals, but tightening that would reject input earlier versions accepted.
+      // These two pin that deliberate leniency so it cannot regress silently.
+      ['foo%bar', 'bare percent in a literal (deliberately lenient)'],
+      ["foo'bar", 'apostrophe in a literal (deliberately lenient)'],
       // expressions
       ['http://example.com/dictionary/{term:1}/{term}', 'absolute URI with expressions'],
       ['dictionary/{term:1}/{term}', 'relative template with expressions'],
@@ -169,11 +174,15 @@ describe('Format Validators', () => {
       ['{;x,y}', 'path-style parameter operator'],
       ['{?x,y}', 'form-style query operator'],
       ['{&x}', 'form-style query continuation operator'],
-      ['{,var}', 'op-reserve operator accepted for ABNF fidelity'],
+      ['{,var}', 'op-reserve "," accepted for ABNF fidelity'],
+      ['{=var}', 'op-reserve "=" accepted for ABNF fidelity'],
+      ['{!var}', 'op-reserve "!" accepted for ABNF fidelity'],
+      ['{@var}', 'op-reserve "@" accepted for ABNF fidelity'],
       ['{a.b:3}', 'dotted varname with a prefix modifier'],
       ['{%41var}', 'varname starting with a percent-encoded triplet'],
       ['{v:1}', 'minimum prefix max-length'],
       ['{v:9999}', 'maximum prefix max-length'],
+      ['{?x:1,y*}', 'variable list mixing a prefix and an explode modifier'],
     ])('should accept %j (%s)', (data) => {
       const validator = ZSchema.create();
       expect(validator.validateSafe(data, uriTemplateSchema).valid).toBe(true);
@@ -193,6 +202,8 @@ describe('Format Validators', () => {
       ['{a..b}', 'consecutive dots in a varname'],
       ['{a.}', 'trailing dot in a varname'],
       ['{a-b}', 'hyphen is not a varchar'],
+      ['{a,b,}', 'trailing comma in the variable list'],
+      ['{a,.b}', 'leading dot on a varspec after a comma'],
       // brace structure
       ['{a{b}', 'nested opening brace'],
       ['{a}}', 'trailing unmatched closing brace'],


### PR DESCRIPTION
## Problem

CI is red on #479 (dependabot bumping the `json-schema-test-suite` submodule `0c7b65d → cc73f5f`). It is a genuine behavioral gap, not flake.

That range adds 8 cases to `optional/format/uri-template.json` in each of draft7 / draft2019-09 / draft2020-12. Four fail — 12 failures per project, across node + chromium + firefox + webkit:

| data | expected | before |
| --- | --- | --- |
| `{}` | invalid | valid |
| `{a,,b}` | invalid | valid |
| `{v:0}` | invalid | valid |
| `{v:10000}` | invalid | valid |

`uriTemplateValidator` applied a literal charset pre-check and balanced braces, but never parsed the *contents* of a `{…}` expression — so any body was accepted, including empty ones and malformed prefix modifiers.

The other four new cases (`""`, `foo}bar`, `a%41b`, `a😀b`) already behaved correctly.

## Fix

Keep the existing pre-check and single indexed scan loop; track where each expression body starts, and on `}` validate the sliced body against one module-scope-hoisted regex built from named RFC 6570 §2 ABNF fragments:

```
varchar  = ALPHA / DIGIT / "_" / pct-encoded
varname  = varchar *( ["."] varchar )
varspec  = varname [ prefix / explode ]      ; prefix = ":" 1-9999, explode = "*"
body     = [ operator ] varspec *( "," varspec )
```

Regex over a hand-rolled scanner because total work stays O(n) (the sum of body lengths never exceeds `uri.length`), every alternation is disjoint on its first character so there is no backtracking blowup, and slice-then-`.test()` per component is already the idiom in this file (`uriValidator` for authority/hostPort/port, `dateTimeValidator` for datePart/timePart). Fragments are composed once at module load, so there is no per-call allocation.

## Deliberate scope limit

Expression bodies only. RFC 6570 also excludes `'` and bare `%` from *literal* text, which the pre-check permits. Tightening that would newly reject inputs like `it's/{x}` and `100%/{x}` with no test demanding it — a silent breaking change. Left lenient, documented in a comment.

## Submodule bump

Bundles the gitlink bump to `cc73f5f` so the new cases actually run here, which supersedes #479.

## Tests

43 table-driven cases added to `test/spec/format-validators.spec.ts` covering the four fixed cases, boundary max-lengths (`{v:1}`, `{v:9999}`, `{v:01}`, `{v:99999}`), all operators including op-reserve, dotted and percent-encoded varnames, brace-structure errors, and non-string passthrough.

Note two easy-to-invert cases pinned as **valid**: `{.a}` (`.` is op-level3 label expansion, not a leading varname dot) and `{,var}` (op-reserve operator plus one varspec — legal per the ABNF, semantics undefined by the spec).

## Verification

- `npm run check` ✅
- `npm run build` ✅
- `npx vitest run --project node -t "uri-template"` — 89/89 ✅
- `npx vitest run --project node test/spec/format-validators.spec.ts` — 56/56 ✅
- `npm test` — **102 test files, 33693 tests passed**, exit 0 (node + browser chromium/firefox/webkit) ✅

No docs change needed: `uri-template` is already listed and already described as "RFC 6570 URI template" in `skills/custom-format-validators/SKILL.md`; `docs/features.md` carries no built-in format list.
