### PR TITLE
fix(format): reject control characters in uri-template literals

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -7,7 +7,7 @@ Line coverage status: **high**
 | File                          |  Line % | Statement % | Function % | Branch % |
 | ----------------------------- | ------: | ----------: | ---------: | -------: |
 | src/errors.ts                 |    100% |        100% |       100% |     100% |
-| src/format-validators.ts      |     95% |         95% |        91% |      94% |
+| src/format-validators.ts      |     96% |         96% |        91% |      94% |
 | src/json-schema-versions.ts   |    100% |        100% |       100% |     100% |
 | src/json-schema.ts            |     98% |         98% |       100% |      98% |
 | src/json-validation.ts        |     91% |         91% |       100% |      89% |

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -294,8 +294,9 @@ const uriTemplateValidator: FormatValidatorFn = (uri: unknown) => {
     return true;
   }
   // URI template allows braces for expressions.
-  // Literal text is checked leniently here: RFC 6570 also excludes "'" and bare "%" from
-  // literals, but tightening that would reject inputs accepted by earlier versions.
+  // Literal text is checked leniently here: RFC 6570 also excludes "'", bare "%" and the C1
+  // controls (%x80-%x9F) from literals, but tightening those would reject inputs accepted by
+  // earlier versions. C0 controls and DEL are rejected in the scan below.
   if (!/^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?[^"\\<>^`| ]*$/.test(uri)) {
     return false;
   }
@@ -304,13 +305,19 @@ const uriTemplateValidator: FormatValidatorFn = (uri: unknown) => {
   // read a stale index — the null check narrows it to a number.
   let expressionStart: number | null = null;
   for (let idx = 0; idx < uri.length; idx++) {
-    const ch = uri[idx];
-    if (ch === '{') {
+    const code = uri.charCodeAt(idx);
+    // RFC 6570 §2.1: literals start at %x21, so C0 controls and DEL are never literal text.
+    // Checking every position is safe as well as cheaper: an expression body containing one
+    // would already fail the varchar rule in URI_TEMPLATE_EXPRESSION_REGEX.
+    if (code <= 0x1f || code === 0x7f) {
+      return false;
+    }
+    if (code === 0x7b /* { */) {
       if (expressionStart !== null) {
         return false;
       }
       expressionStart = idx + 1;
-    } else if (ch === '}') {
+    } else if (code === 0x7d /* } */) {
       if (expressionStart === null) {
         return false;
       }

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -163,6 +163,7 @@ describe('Format Validators', () => {
       // These two pin that deliberate leniency so it cannot regress silently.
       ['foo%bar', 'bare percent in a literal (deliberately lenient)'],
       ["foo'bar", 'apostrophe in a literal (deliberately lenient)'],
+      ['foo\u0080bar', 'C1 control in a literal (deliberately lenient)'],
       // expressions
       ['http://example.com/dictionary/{term:1}/{term}', 'absolute URI with expressions'],
       ['dictionary/{term:1}/{term}', 'relative template with expressions'],
@@ -210,6 +211,11 @@ describe('Format Validators', () => {
       ['}{', 'closing brace before an opening brace'],
       ['foo}bar', 'unmatched closing brace in a literal'],
       ['http://example.com/dictionary/{term:1}/{term', 'unterminated expression'],
+      // literal charset — RFC 6570 §2.1 starts literals at %x21, so no C0 control or DEL
+      ['foo\u007Fbar', 'a delete character in a literal'],
+      ['foo\u0000bar', 'a NUL character in a literal'],
+      ['foo\u001Fbar', 'a unit-separator control character in a literal'],
+      ['{foo\u007Fbar}', 'a delete character inside an expression body'],
     ])('should reject %j (%s)', (data) => {
       const validator = ZSchema.create();
       expect(validator.validateSafe(data, uriTemplateSchema).valid).toBe(false);

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -158,9 +158,9 @@ describe('Format Validators', () => {
       ['a%41b', 'percent-encoded triplet in a literal'],
       ['a\u{1F600}b', 'supplementary plane character in a literal'],
       ['http://example.com/dictionary', 'absolute URI without expressions'],
-      // Literal text is validated leniently on purpose: RFC 6570 excludes bare "%" and "'"
-      // from literals, but tightening that would reject input earlier versions accepted.
-      // These two pin that deliberate leniency so it cannot regress silently.
+      // Literal text is validated leniently on purpose: RFC 6570 excludes bare "%", "'" and
+      // the C1 controls from literals, but tightening that would reject input earlier versions
+      // accepted. These three pin that deliberate leniency so it cannot regress silently.
       ['foo%bar', 'bare percent in a literal (deliberately lenient)'],
       ["foo'bar", 'apostrophe in a literal (deliberately lenient)'],
       ['foo\u0080bar', 'C1 control in a literal (deliberately lenient)'],


### PR DESCRIPTION
## Problem

Dependabot #482 bumps the `test/public/json-schema-test-suite` submodule to `15fe552`, which adds seven upstream `uri-template` test commits. CI failed on exactly one of the new cases — across draft6/draft7/draft2019-09/draft2020-12 and all four runners (node + chromium/firefox/webkit):

```
draft2020-12/optional/format/uri-template.json > format: uri-template a delete character in a literal is invalid
AssertionError: expected true to be false
Test Files  4 failed | 98 passed (102)
```

RFC 6570 §2.1 starts the `literals` rule at `%x21`, so C0 controls and DEL are never literal text. The literal-charset gate in `uriTemplateValidator` only excluded `" \ < > ^ ` |` and space, so `a<DEL>b` was accepted as a valid `uri-template`.

## Fix

Fold the control-character check into the **existing** brace-matching scan rather than adding a second regex pass, and switch that loop to `charCodeAt` while there — one indexed numeric compare per character replaces the per-character string reads, so no new allocation or regex lands on the hot path (and the line-299 regex stays untouched, avoiding `no-control-regex`).

Checking every position rather than only literal runs is safe as well as cheaper: an expression body containing a control character would already fail the `varchar` rule in `URI_TEMPLATE_EXPRESSION_REGEX`.

| input | before | after |
| --- | --- | --- |
| `a\u007Fb` | accepted | **rejected** (the upstream case) |
| `a\u0000b`, `a\u001Fb` | accepted | **rejected** (same gap, not covered upstream) |
| `a b` | rejected | rejected |
| `a%41b`, `a'b`, `a\u0080b`, `a😀b` | accepted | accepted |

Literals stay lenient for `'`, bare `%` and the C1 controls (`%x80`–`%x9F`), consistent with the carve-out already documented in the file — tightening those would reject inputs earlier versions accepted, and no test requires it. The comment above the regex now names C1 explicitly so the boundary is documented where the check lives.

## Scope

Deliberately **not** implementing the full RFC 6570 `literals` ABNF (C1 controls plus restricting non-ASCII to `ucschar`/`iprivate`). That would be a behavioural break beyond what any test asks for and would contradict the file's stated backcompat leniency.

## Tests

New cases in `test/spec/format-validators.spec.ts`, following the existing `[value, description]` style:

- reject: `foo\u007Fbar`, `foo\u0000bar`, `foo\u001Fbar`, `{foo\u007Fbar}`
- accept: `foo\u0080bar` — pins the deliberate C1 leniency so it cannot be tightened by accident

## Submodule bump

Carries the `15fe552` bump itself, so CI validates the fix against the suite that exercises it. This supersedes #482, which dependabot should auto-close once `main` points at `15fe552` — same pattern as #480 superseding #479.

## Verification

- `npm test` — **102 test files / 34097 tests passed** (was `4 failed | 98 passed` on #482)
- `npx vitest run --project node -t "a delete character in a literal is invalid"` — 4/4 matched tests pass
- `npx vitest run --project browser test/spec/format-validators.spec.ts` — 3 projects × 69 = 207 passed
- `npm run check` (oxlint + oxfmt) and `npm run build` — clean
