### PR TITLE
fix(format): reject non-ASCII email and apply UTS 46 mapping to idn-hostname

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -45,9 +45,9 @@
 
 ## Dependencies
 
-- **Runtime**: `validator` (format validation: email, IP, URL). One dependency only — minimize additions.
+- **Runtime**: `validator` (format validation: email, IP, URL), `punycode` (IDNA A-label transcoding), `safe-regex2` (ReDoS guard). Keep this list short — minimize additions.
 - **Optional**: `commander` (CLI support via `bin/z-schema`). Not required for library usage.
-- Avoid adding new runtime dependencies unless absolutely necessary.
+- Avoid adding new runtime dependencies unless absolutely necessary. Both UMD targets set `deps: { alwaysBundle: [/.*/] }` in [tsdown.config.ts](../tsdown.config.ts), so every runtime dependency is inlined into `umd/ZSchema.js` **and** `umd/ZSchema.min.js` — a dependency carrying a large Unicode table (e.g. `tr46`, ~220 KB) roughly doubles the browser bundle. Prefer a narrow hand-rolled implementation when it covers the required behavior; see the UTS 46 mapping step in [src/utils/hostname.ts](../src/utils/hostname.ts).
 
 ## Utility Functions
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -20,7 +20,7 @@ Line coverage status: **high**
 | src/utils/clone.ts            |     97% |         98% |       100% |      94% |
 | src/utils/constants.ts        |    100% |        100% |       100% |     100% |
 | src/utils/date.ts             |    100% |        100% |       100% |     100% |
-| src/utils/hostname.ts         |     97% |         97% |       100% |      97% |
+| src/utils/hostname.ts         |     97% |         98% |       100% |      98% |
 | src/utils/json.ts             |     98% |         98% |       100% |      97% |
 | src/utils/properties.ts       |    100% |        100% |       100% |      75% |
 | src/utils/rfc-3986.ts         |    100% |        100% |       100% |     100% |

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -20,7 +20,7 @@ Line coverage status: **high**
 | src/utils/clone.ts            |     97% |         98% |       100% |      94% |
 | src/utils/constants.ts        |    100% |        100% |       100% |     100% |
 | src/utils/date.ts             |    100% |        100% |       100% |     100% |
-| src/utils/hostname.ts         |     96% |         96% |       100% |      97% |
+| src/utils/hostname.ts         |     97% |         97% |       100% |      97% |
 | src/utils/json.ts             |     98% |         98% |       100% |      97% |
 | src/utils/properties.ts       |    100% |        100% |       100% |      75% |
 | src/utils/rfc-3986.ts         |    100% |        100% |       100% |     100% |

--- a/src/format-validators.ts
+++ b/src/format-validators.ts
@@ -55,11 +55,25 @@ const dateTimeValidator: FormatValidatorFn = (dateTime: unknown) => {
   return parseRfc3339Time(timePart) !== null;
 };
 
+// Matches any code unit outside the ASCII range; hoisted so it is compiled once.
+// eslint-disable-next-line no-control-regex
+const NON_ASCII_REGEX = /[^\u0000-\u007F]/;
+
 const emailValidator: FormatValidatorFn = (email: unknown) => {
   if (typeof email !== 'string') {
     return true;
   }
-  if (isEmailModule.default(email, { require_tld: true, allow_ip_domain: true })) {
+  // RFC 5321/5322 addresses are ASCII-only — Unicode addresses are `idn-email`.
+  // Checked up front because `validator` would otherwise accept non-ASCII in the
+  // local part (its `allow_utf8_local_part` option defaults to true, and applies to
+  // quoted pairs too) and in the domain (`isFQDN` allows non-ASCII label chars).
+  if (NON_ASCII_REGEX.test(email)) {
+    return false;
+  }
+  // `require_tld` is deliberately false: a single-label domain (`test@io`) is a
+  // valid address. Dot placement is still enforced by `isFQDN`, so `test@.iana.org`,
+  // `test@iana.org.` and `test@iana..com` remain invalid.
+  if (isEmailModule.default(email, { require_tld: false, allow_ip_domain: true })) {
     return true;
   }
 
@@ -74,7 +88,7 @@ const emailValidator: FormatValidatorFn = (email: unknown) => {
     return false;
   }
 
-  return isEmailModule.default(`${localPart}@example.com`, { require_tld: true });
+  return isEmailModule.default(`${localPart}@example.com`, { require_tld: false });
 };
 
 const hostnameValidator: FormatValidatorFn = (hostname: unknown) => {

--- a/src/utils/hostname.ts
+++ b/src/utils/hostname.ts
@@ -6,16 +6,127 @@ const IDN_SEPARATOR_TEST_REGEX = /[\u3002\uFF0E\uFF61]/;
 
 // IDNA2008 (RFC 5890-5893) support below is a hand-rolled approximation built on
 // General_Category / Script Unicode-property regexes (JS regex has no
-// \p{Bidi_Class} or \p{Joining_Type}). It covers the JSON-Schema-Test-Suite
+// \p{Bidi_Class} or \p{Joining_Type}), plus a UTS 46 mapping step
+// (applyUts46Mapping) for idn-hostname. It covers the JSON-Schema-Test-Suite
 // corpus, not the full IDNA table. Known limitations: joining-context (CONTEXTJ)
 // only models Arabic script; the ZWJ/ZWNJ Virama context recognizes only the
-// Devanagari virama U+094D (not other scripts' viramas); Bidi class detection
-// covers L/R/AL/AN/EN/NSM and treats everything else as ON; and U-labels are not
-// required to be in Unicode NFC form. All regexes/Sets are hoisted to module scope
-// so they are compiled once (format validation runs on hot paths).
+// Devanagari virama U+094D (not other scripts' viramas); and Bidi class detection
+// covers L/R/AL/AN/EN/NSM and treats everything else as ON.
+//
+// The mapping step is nontransitional (UTS 46 section 4): the deviation code
+// points U+00DF, U+03C2, U+200C and U+200D are preserved rather than folded. It
+// derives the `mapped` column from String.prototype.toLowerCase plus a
+// per-code-point NFKC, which reproduces the real table for the case-mapped and
+// compatibility entries but not for `disallowed_STD3_valid` code points (e.g.
+// U+00A1, reachable through an A-label such as "xn--7a", is accepted where UTS 46
+// with STD3 rules would reject it) nor for \p{No} dot-formers (e.g. U+2488 "1.",
+// which is accepted as a single label -- a pre-existing gap the mapping step
+// neither fixes nor widens). The plain `hostname` format does not map at all;
+// isValidHostname rejects every non-ASCII code point outright.
+//
+// All regexes/Sets are hoisted to module scope so they are compiled once (format
+// validation runs on hot paths).
 
 // Matches an A-label (ACE) prefix; hoisted so it is compiled once, not per label.
 const XN_LABEL_REGEX = /^xn--/i;
+
+// The exact UTS 46 IdnaMappingTable `ignored` status, NOT
+// \p{Default_Ignorable_Code_Point}: 3880 Default_Ignorable code points are
+// DISALLOWED rather than ignored -- notably U+061C ALM, U+200E/200F LRM/RLM and
+// U+202A-202E (the bidi overrides). Deleting those would accept bidi-spoofed
+// hostnames, and no JSON-Schema-Test-Suite case covers it, so the guard lives in
+// the idn-hostname unit tests instead. Encoding the real set also means ZWNJ/ZWJ
+// need no exception here: they are UTS 46 `deviation`, not `ignored`, so
+// nontransitional processing keeps them for the CONTEXTJ checks below.
+const UTS46_IGNORED_TEST_REGEX =
+  // Several members of this set (U+034F, U+17B4/B5, U+180B-180F, U+1D173-1D17A and the
+  // U+E0100-E01EF variation selectors) are General_Category=Mn, so no-misleading-character-class fires
+  // on the class; they are code point escapes, not literal combining sequences, and the
+  // membership is dictated by the UTS 46 table.
+  // eslint-disable-next-line no-misleading-character-class
+  /[\u00AD\u034F\u115F\u1160\u17B4\u17B5\u180B-\u180F\u200B\u2060-\u2064\u206A-\u206F\u3164\uFE00-\uFE0F\uFEFF\uFFA0\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0100}-\u{E01EF}]/u;
+// The same character class with `g`, for `replace`. Deliberately duplicated rather
+// than shared via `new RegExp(source, flags)`: literals stay greppable, and this
+// mirrors the IDN_SEPARATOR_REGEX/_TEST_REGEX pairing above, which exists because
+// `.test()` on a `g`-flagged regex advances a stateful `lastIndex`.
+const UTS46_IGNORED_REGEX =
+  // eslint-disable-next-line no-misleading-character-class -- see above
+  /[\u00AD\u034F\u115F\u1160\u17B4\u17B5\u180B-\u180F\u200B\u2060-\u2064\u206A-\u206F\u3164\uFE00-\uFE0F\uFEFF\uFFA0\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0100}-\u{E01EF}]/gu;
+
+// UTS 46 section 4 step 1 (Map), nontransitional processing. Deliberately NOT
+// applied by isValidHostname, which rejects every non-ASCII code point outright.
+const applyUts46Mapping = (hostname: string): string => {
+  // One charCode pass classifies the input, so the two fast paths below cost a
+  // single scan between them rather than a regex test each.
+  let hasNonAscii = false;
+  let needsMapping = false;
+  for (let idx = 0; idx < hostname.length; idx++) {
+    const code = hostname.charCodeAt(idx);
+    if (code > 0x7f) {
+      hasNonAscii = true;
+      needsMapping = true;
+      break;
+    }
+    // Lowercase ASCII letters, digits, '.' and '-' are already fully mapped: no
+    // ASCII code point is `ignored`, carries a compatibility mapping, or is
+    // altered by NFC.
+    if (!((code >= 0x61 && code <= 0x7a) || (code >= 0x30 && code <= 0x39) || code === 0x2e || code === 0x2d)) {
+      needsMapping = true;
+    }
+  }
+  // Already-mapped ASCII -- by far the common case. Returned by identity.
+  if (!needsMapping) {
+    return hostname;
+  }
+  // Any other all-ASCII hostname needs case mapping only.
+  if (!hasNonAscii) {
+    return hostname.toLowerCase();
+  }
+
+  let mapped = hostname;
+  // 1. Delete `ignored` code points. Must precede the fold below: U+FFA0 is
+  //    `ignored`, but NFKC would turn it into U+1160 rather than remove it.
+  if (UTS46_IGNORED_TEST_REGEX.test(mapped)) {
+    mapped = mapped.replace(UTS46_IGNORED_REGEX, '');
+  }
+  // 2. Case mapping -- toLowerCase, never case folding. Nontransitional processing
+  //    preserves the deviation code points U+00DF and U+03C2, which folding would
+  //    turn into "ss" and sigma; toLowerCase leaves both alone while still applying
+  //    genuine `mapped` entries such as U+212A KELVIN SIGN -> "k".
+  mapped = mapped.toLowerCase();
+  // 3. Compatibility fold. NFKC output is always in NFC form, so a string that
+  //    NFKC leaves untouched is both fully folded and already NFC -- the common
+  //    case for real IDNs, since Greek, Cyrillic, Hangul and Han labels carry no
+  //    compatibility mappings. One whole-string call to detect that is worth it:
+  //    it skips both the per-code-point loop and the recomposition in step 4. A
+  //    code point cannot fold under the per-code-point pass while leaving the
+  //    whole string fixed -- both apply the same NFKC to the same code point.
+  const compatFolded = mapped.normalize('NFKC');
+  if (compatFolded === mapped) {
+    return mapped;
+  }
+  // Something folds, so redo it one code point at a time: whole-string NFKC would
+  // also apply the mappings this implementation must withhold. A mapping that
+  // introduces a '.' is skipped -- of the 31 non-ASCII code points whose NFKC
+  // output contains a dot, every one is DISALLOWED or disallowed_STD3_mapped
+  // except U+FF0E, which IDN_SEPARATOR_REGEX already handles. Without the guard
+  // U+2024 ONE DOT LEADER would silently turn "a<U+2024>b" into the two-label
+  // "a.b". Iterated by code point (not index) so a surrogate pair folds as one
+  // character, matching the DISALLOWED loop in isValidIdnUnicodeLabel.
+  let folded = '';
+  for (const char of mapped) {
+    if (char.charCodeAt(0) < 0x80) {
+      folded += char;
+      continue;
+    }
+    const normalized = char.normalize('NFKC');
+    folded += normalized.includes('.') ? char : normalized;
+  }
+  // 4. Normalize to NFC. Fixes non-NFC U-labels and composes the combining marks
+  //    the per-code-point fold leaves behind (halfwidth katakana U+FF76 U+FF9E ->
+  //    U+30AB U+3099 -> U+30AC).
+  return folded.normalize('NFC');
+};
 
 // RFC 5892 section 2.6 lists a handful of code points that are PVALID (or governed
 // by a contextual rule) despite being Punctuation/Symbol. A blanket "reject
@@ -354,7 +465,12 @@ export const isValidHostname = (hostname: string): boolean => {
 };
 
 export const isValidIdnHostname = (hostname: string): boolean => {
-  const normalizedHostname = hostname.replace(IDN_SEPARATOR_REGEX, '.');
+  // UTS 46 order: map first, then split on the label separators. U+FF61 maps to
+  // U+3002 rather than '.', so the separator replacement has to follow the mapping.
+  let normalizedHostname = applyUts46Mapping(hostname);
+  if (IDN_SEPARATOR_TEST_REGEX.test(normalizedHostname)) {
+    normalizedHostname = normalizedHostname.replace(IDN_SEPARATOR_REGEX, '.');
+  }
   const labels = splitHostnameLabels(normalizedHostname);
   if (labels === null) {
     return false;

--- a/src/utils/hostname.ts
+++ b/src/utils/hostname.ts
@@ -21,7 +21,9 @@ const IDN_SEPARATOR_TEST_REGEX = /[\u3002\uFF0E\uFF61]/;
 // U+00A1, reachable through an A-label such as "xn--7a", is accepted where UTS 46
 // with STD3 rules would reject it) nor for \p{No} dot-formers (e.g. U+2488 "1.",
 // which is accepted as a single label -- a pre-existing gap the mapping step
-// neither fixes nor widens). The plain `hostname` format does not map at all;
+// neither fixes nor widens). U+0345 and the U+1F80-U+1FFC block are handled
+// explicitly because omitting them lets invalid labels validate rather than
+// merely rejecting valid ones. The plain `hostname` format does not map at all;
 // isValidHostname rejects every non-ASCII code point outright.
 //
 // All regexes/Sets are hoisted to module scope so they are compiled once (format
@@ -53,6 +55,15 @@ const UTS46_IGNORED_REGEX =
   // eslint-disable-next-line no-misleading-character-class -- see above
   /[\u00AD\u034F\u115F\u1160\u17B4\u17B5\u180B-\u180F\u200B\u2060-\u2064\u206A-\u206F\u3164\uFE00-\uFE0F\uFEFF\uFFA0\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0100}-\u{E01EF}]/gu;
 
+// Every code point that may act as a label separator, including the ASCII '.'.
+// Used to withhold a compatibility mapping that would introduce one.
+const LABEL_SEPARATOR_TEST_REGEX = /[.\u3002\uFF0E\uFF61]/;
+
+// U+0345 COMBINING GREEK YPOGEGRAMMENI, plus the U+1F80-U+1FFC block whose
+// precomposed code points decompose through it (63 of them; the range also spans
+// a few that do not, which the replace below simply leaves alone).
+const YPOGEGRAMMENI_TEST_REGEX = /[\u0345\u1F80-\u1FFC]/;
+const YPOGEGRAMMENI_REGEX = /\u0345/g;
 // UTS 46 section 4 step 1 (Map), nontransitional processing. Deliberately NOT
 // applied by isValidHostname, which rejects every non-ASCII code point outright.
 const applyUts46Mapping = (hostname: string): string => {
@@ -94,11 +105,26 @@ const applyUts46Mapping = (hostname: string): string => {
   //    turn into "ss" and sigma; toLowerCase leaves both alone while still applying
   //    genuine `mapped` entries such as U+212A KELVIN SIGN -> "k".
   mapped = mapped.toLowerCase();
-  // 3. Compatibility fold. NFKC output is always in NFC form, so a string that
+  // 3. UTS 46 maps U+0345 COMBINING GREEK YPOGEGRAMMENI to U+03B9 GREEK SMALL
+  //    LETTER IOTA (its mapping column follows NFKC_Casefold, whose case-folding
+  //    step covers this; plain NFKC does not). Skipping it is not cosmetic: it
+  //    leaves a Bidi_Class=NSM combining mark where a Bidi_Class=L letter belongs,
+  //    so "<alef>U+0345" would pass the RFC 5893 Bidi rule as R+NSM instead of
+  //    failing as R+L, and it understates label length -- U+1FB3 must expand to
+  //    two code points, so 29 of them are a 65-octet A-label, over the limit.
+  //    Applied over NFD so the 63 precomposed code points in U+1F80-U+1FFC that
+  //    decompose through U+0345 are covered by the same rule; the trailing NFC
+  //    undoes the decomposition. Runs before the fold below because the
+  //    NFKC-invariance shortcut there would otherwise skip it (U+1FB3 is
+  //    NFKC-invariant).
+  if (YPOGEGRAMMENI_TEST_REGEX.test(mapped)) {
+    mapped = mapped.normalize('NFD').replace(YPOGEGRAMMENI_REGEX, '\u03B9').normalize('NFC');
+  }
+  // 4. Compatibility fold. NFKC output is always in NFC form, so a string that
   //    NFKC leaves untouched is both fully folded and already NFC -- the common
   //    case for real IDNs, since Greek, Cyrillic, Hangul and Han labels carry no
   //    compatibility mappings. One whole-string call to detect that is worth it:
-  //    it skips both the per-code-point loop and the recomposition in step 4. A
+  //    it skips both the per-code-point loop and the recomposition in step 5. A
   //    code point cannot fold under the per-code-point pass while leaving the
   //    whole string fixed -- both apply the same NFKC to the same code point.
   const compatFolded = mapped.normalize('NFKC');
@@ -106,13 +132,16 @@ const applyUts46Mapping = (hostname: string): string => {
     return mapped;
   }
   // Something folds, so redo it one code point at a time: whole-string NFKC would
-  // also apply the mappings this implementation must withhold. A mapping that
-  // introduces a '.' is skipped -- of the 31 non-ASCII code points whose NFKC
-  // output contains a dot, every one is DISALLOWED or disallowed_STD3_mapped
-  // except U+FF0E, which IDN_SEPARATOR_REGEX already handles. Without the guard
-  // U+2024 ONE DOT LEADER would silently turn "a<U+2024>b" into the two-label
-  // "a.b". Iterated by code point (not index) so a surrogate pair folds as one
-  // character, matching the DISALLOWED loop in isValidIdnUnicodeLabel.
+  // also apply the mappings this implementation must withhold. A mapping whose
+  // output contains a label separator is skipped, leaving the original code point
+  // for the separator replacement and the DISALLOWED check to judge. Exactly 33
+  // non-ASCII code points fold to a string containing one; only U+FF0E and U+FF61
+  // are UTS 46 `mapped`, and IDN_SEPARATOR_REGEX already turns both into '.'. The
+  // other 31 are DISALLOWED or disallowed_STD3_mapped, so without the guard
+  // U+2024 ONE DOT LEADER (-> '.') and U+FE12 (-> U+3002) would each forge a label
+  // separator and split "a<cp>b" into two valid labels.
+  // Iterated by code point (not index) so a surrogate pair folds as one character,
+  // matching the DISALLOWED loop in isValidIdnUnicodeLabel.
   let folded = '';
   for (const char of mapped) {
     if (char.charCodeAt(0) < 0x80) {
@@ -120,9 +149,9 @@ const applyUts46Mapping = (hostname: string): string => {
       continue;
     }
     const normalized = char.normalize('NFKC');
-    folded += normalized.includes('.') ? char : normalized;
+    folded += LABEL_SEPARATOR_TEST_REGEX.test(normalized) ? char : normalized;
   }
-  // 4. Normalize to NFC. Fixes non-NFC U-labels and composes the combining marks
+  // 5. Normalize to NFC. Fixes non-NFC U-labels and composes the combining marks
   //    the per-code-point fold leaves behind (halfwidth katakana U+FF76 U+FF9E ->
   //    U+30AB U+3099 -> U+30AC).
   return folded.normalize('NFC');
@@ -497,8 +526,19 @@ export const isValidIdnHostname = (hostname: string): boolean => {
     // U-label must reproduce the original A-label. This also rejects an A-label
     // that decodes to pure ASCII, since such a label never re-encodes to an "xn--"
     // form (RFC 5890 §2.3.2.1, RFC 5891 §5.4).
-    if (XN_LABEL_REGEX.test(label) && aLabel.toLowerCase() !== label.toLowerCase()) {
-      return false;
+    if (XN_LABEL_REGEX.test(label)) {
+      if (aLabel.toLowerCase() !== label.toLowerCase()) {
+        return false;
+      }
+      // RFC 5891 §5.4 / UTS 46 validity criterion 1 -- the decoded U-label must be
+      // in NFC form. applyUts46Mapping cannot enforce this: an A-label is pure
+      // ASCII, so it is returned untouched by the mapping and only the Punycode
+      // decode below produces the Unicode that needs normalizing. Without this,
+      // "xn--u-ccb" (decoding to U+0075 U+0308 rather than the composed U+00FC)
+      // would validate.
+      if (unicodeLabel.normalize('NFC') !== unicodeLabel) {
+        return false;
+      }
     }
 
     // RFC 5890 §2.3.2.1 — the A-label form of any label must not exceed 63 octets.

--- a/test/ZSchemaTestSuite/Issue48.ts
+++ b/test/ZSchemaTestSuite/Issue48.ts
@@ -16,13 +16,22 @@ export default {
       valid: true,
     },
     {
+      // A single-label domain is a valid address per RFC 5321, and the official
+      // JSON-Schema-Test-Suite asserts it ("a single-label domain is valid",
+      // optional/format/email.json). This case previously expected `false`, back
+      // when the validator ran with validator.js `require_tld: true`.
+      description: 'should pass validation #3',
+      data: 'foo@bar',
+      valid: true,
+    },
+    {
       description: 'should fail validation #1',
       data: 'foobar.baz',
       valid: false,
     },
     {
       description: 'should fail validation #2',
-      data: 'foo@bar',
+      data: 'foo@bar..baz',
       valid: false,
     },
   ],

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -497,8 +497,6 @@ describe('Format Validators', () => {
     });
   });
 
-  // Reaches into src/utils/rfc-3986.ts on purpose, unlike every block above: this pins a property
-  // of the grammar sources themselves, not the behaviour of a registered format.
   describe('Email Format Validator', () => {
     const emailSchema = { type: 'string', format: 'email' };
 
@@ -592,6 +590,13 @@ describe('Format Validators', () => {
       ['\u00DF\u03C2\u0F0B\u3007', 'the U+00DF and U+03C2 deviations are preserved'],
       ['\u0915\u094D\u200C\u0937', 'ZWNJ is a deviation, not ignored, so CONTEXTJ still sees it'],
       ['\u0915\u094D\u200D\u0937', 'ZWJ is a deviation, not ignored, so CONTEXTJ still sees it'],
+      // U+FF61 and U+FF0E are the only two UTS 46 `mapped` code points whose fold
+      // output contains a label separator, so the separator guard must not swallow
+      // them -- IDN_SEPARATOR_REGEX turns both into '.'.
+      ['a\uFF61b', 'a fullwidth halfwidth ideographic full stop separates labels'],
+      ['a\uFF0Eb', 'a fullwidth full stop separates labels'],
+      ['a\u3002b', 'an ideographic full stop separates labels'],
+      ['\u1FB3', 'U+1FB3 maps to alpha + iota via the U+0345 rule'],
     ])('should accept %j (%s)', (data) => {
       const validator = ZSchema.create();
       expect(validator.validateSafe(data, idnHostnameSchema).valid).toBe(true);
@@ -617,6 +622,17 @@ describe('Format Validators', () => {
       ['\u200B', 'a hostname that is empty after mapping'],
       ['a.\u200B.b', 'a label that is empty after mapping'],
       ['\uFF41'.repeat(64), 'a label of 64 fullwidth letters exceeds 63 octets after mapping'],
+      // The fold must not introduce a NON-ASCII separator either: U+FE12 is
+      // DISALLOWED but folds to U+3002, which IDN_SEPARATOR_REGEX would then treat
+      // as a label break. Guarding only the ASCII '.' let this through.
+      ['a\uFE12b', 'U+FE12 must not forge an ideographic full stop separator'],
+      // UTS 46 maps U+0345 to U+03B9; leaving it in place understates both its Bidi
+      // class (NSM where an L letter belongs) and the label length.
+      ['\u05D0\u0345', 'alef + U+0345 is R+L and must fail the Bidi rule'],
+      ['\u1FB3'.repeat(29), '29 x U+1FB3 expands to a 65-octet A-label'],
+      // RFC 5891 section 5.4 -- a decoded U-label must be in NFC form. The mapping
+      // step cannot catch this: an A-label is pure ASCII and passes through untouched.
+      ['xn--u-ccb.com', 'an A-label decoding to U+0075 U+0308 rather than U+00FC'],
       ['XN--aa---o47jg78q', 'lowercasing does not rescue hyphens in positions 3 and 4'],
     ])('should reject %j (%s)', (data) => {
       const validator = ZSchema.create();
@@ -629,6 +645,8 @@ describe('Format Validators', () => {
     });
   });
 
+  // Reaches into src/utils/rfc-3986.ts on purpose, unlike every block above: this pins a property
+  // of the grammar sources themselves, not the behaviour of a registered format.
   describe('URI Grammar Source Invariants', () => {
     // The `u` flag is derived from the class bodies rather than passed in. Getting that wrong is
     // silent rather than loud: outside `u` mode a `\u{...}` escape is an identity escape, so the

--- a/test/spec/format-validators.spec.ts
+++ b/test/spec/format-validators.spec.ts
@@ -499,6 +499,136 @@ describe('Format Validators', () => {
 
   // Reaches into src/utils/rfc-3986.ts on purpose, unlike every block above: this pins a property
   // of the grammar sources themselves, not the behaviour of a registered format.
+  describe('Email Format Validator', () => {
+    const emailSchema = { type: 'string', format: 'email' };
+
+    it.each([
+      ['test@io', 'a single-label domain is a valid address (RFC 5321)'],
+      ['test@255.255.255.255', 'an unbracketed IPv4 domain'],
+      ['"test"@iana.org', 'a quoted local part'],
+      ['a@[IPv6:::1]', 'an IPv6 address literal, which uses the bracketed-literal path'],
+      ['a@[ipv6:::1]', 'a lowercase IPv6 tag in an address literal'],
+    ])('should accept %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, emailSchema).valid).toBe(true);
+    });
+
+    // The ASCII `email` format is ASCII-only (RFC 5321/5322); Unicode addresses are
+    // `idn-email`. The first three rows are each accepted by validator.js on their own,
+    // so together they pin the up-front non-ASCII rejection rather than any isEmail option.
+    it.each([
+      ['a\u00E9@iana.org', 'a non-ASCII character in the local part'],
+      ['a@\u00E9.org', 'a non-ASCII character in the domain'],
+      ['"test\\\u00A9"@iana.org', 'a non-ASCII character in a quoted pair'],
+      ['a\uFF20iana.org', 'a fullwidth commercial at is not a separator'],
+      ['test@.iana.org', 'a domain starting with a dot is still rejected without require_tld'],
+      ['test@iana.org.', 'a domain ending with a dot is still rejected without require_tld'],
+      ['test@iana..com', 'two subsequent dots in the domain are still rejected'],
+      ['test@-iana.org', 'a domain label starting with a hyphen'],
+      ['a@[1.2.3]', 'an IPv4 address literal with three octets'],
+    ])('should reject %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, emailSchema).valid).toBe(false);
+    });
+
+    // Format validators apply to strings only; every other type is vacuously valid.
+    it.each([12, 13.7, {}, [], false, null])('should ignore non-string input %j', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, { format: 'email' }).valid).toBe(true);
+    });
+  });
+
+  describe('Hostname Format Validator', () => {
+    const hostnameSchema = { type: 'string', format: 'hostname' };
+
+    it.each([
+      ['www.example.com', 'a plain hostname'],
+      ['xn--nxasmq6b', 'an A-label whose decoded U-label is valid'],
+    ])('should accept %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, hostnameSchema).valid).toBe(true);
+    });
+
+    // The UTS 46 mapping step belongs to `idn-hostname` only: the plain `hostname`
+    // format rejects every non-ASCII code point outright, so neither the fullwidth
+    // full stop nor the KELVIN SIGN may be mapped into an ASCII hostname here.
+    it.each([
+      ['example\uFF0Ecom', 'a fullwidth full stop is not mapped to a label separator'],
+      ['\u212Aelvin.example.com', 'the KELVIN SIGN is not case-mapped to "k"'],
+      ['-hostname', 'a label starting with a hyphen'],
+    ])('should reject %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, hostnameSchema).valid).toBe(false);
+    });
+
+    it.each([12, 13.7, {}, [], false, null])('should ignore non-string input %j', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, { format: 'hostname' }).valid).toBe(true);
+    });
+  });
+
+  describe('IDN Hostname Format Validator', () => {
+    const idnHostnameSchema = { type: 'string', format: 'idn-hostname' };
+
+    it.each([
+      // UTS 46 mapping step (section 4 step 1), nontransitional.
+      ['a\u200Bb', 'an ignored ZERO WIDTH SPACE is deleted by the mapping'],
+      ['a\u00ADb', 'an ignored SOFT HYPHEN is deleted by the mapping'],
+      // U+FFA0 is ignored, so it must be deleted before the compatibility fold --
+      // NFKC would otherwise turn it into U+1160 instead of removing it.
+      ['a\uFFA0b', 'HALFWIDTH HANGUL FILLER is ignored, not width-folded'],
+      ['\uFF41'.repeat(63), 'a label of 63 fullwidth letters is 63 octets after mapping'],
+      ['\uFF58\uFF4E--nxasmq6b', 'an ACE prefix produced by the mapping decodes as an A-label'],
+      ['\uFF11\uFF12\uFF13', 'fullwidth digits map to ASCII digits'],
+      ['cafe\u0301.com', 'a non-NFC U-label is normalised to NFC'],
+      // Per-code-point NFKC leaves a combining mark behind; the final NFC composes it.
+      ['\uFF76\uFF9E', 'halfwidth katakana plus a sound mark compose to U+30AC'],
+      ['\u212Aelvin', 'the KELVIN SIGN case-maps to "k"'],
+      ['\u337F.com', 'SQUARE CORPORATION maps to its four-ideograph sequence'],
+      ['Example.COM', 'uppercase ASCII takes the ASCII case-mapping fast path'],
+      ['xn--NXASMQ6B', 'an A-label with an uppercase Punycode body'],
+      // Nontransitional processing: these deviations must survive the mapping. Case
+      // *folding* would turn U+00DF into "ss" and U+03C2 into sigma.
+      ['\u00DF\u03C2\u0F0B\u3007', 'the U+00DF and U+03C2 deviations are preserved'],
+      ['\u0915\u094D\u200C\u0937', 'ZWNJ is a deviation, not ignored, so CONTEXTJ still sees it'],
+      ['\u0915\u094D\u200D\u0937', 'ZWJ is a deviation, not ignored, so CONTEXTJ still sees it'],
+    ])('should accept %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, idnHostnameSchema).valid).toBe(true);
+    });
+
+    it.each([
+      // These four guard against deriving the ignored set from the
+      // Default_Ignorable_Code_Point property: 3880 Default_Ignorable code points are
+      // DISALLOWED rather than ignored, and deleting the bidi controls below would
+      // accept spoofed hostnames. No JSON-Schema-Test-Suite case covers this, so
+      // these rows are the only thing that fails if the set is ever "simplified".
+      ['a\u202Eb', 'RIGHT-TO-LEFT OVERRIDE is DISALLOWED, not ignored'],
+      ['a\u202Ab', 'LEFT-TO-RIGHT EMBEDDING is DISALLOWED, not ignored'],
+      ['a\u200Eb', 'LEFT-TO-RIGHT MARK is DISALLOWED, not ignored'],
+      ['a\u061Cb', 'ARABIC LETTER MARK is DISALLOWED, not ignored'],
+      // The compatibility fold must never introduce a label separator.
+      ['a\u2024b', 'ONE DOT LEADER must not be folded into a label separator'],
+      ['a\uFE52b', 'SMALL FULL STOP must not be folded into a label separator'],
+      ['a\u2026b', 'HORIZONTAL ELLIPSIS must not be folded into label separators'],
+      ['\uFDFA.com', 'an Arabic ligature folding to a sequence containing spaces'],
+      ['a\uFFE3b', 'FULLWIDTH MACRON folds to a space, which is DISALLOWED'],
+      // A label the mapping empties is invalid (UTS 46 VerifyDnsLength).
+      ['\u200B', 'a hostname that is empty after mapping'],
+      ['a.\u200B.b', 'a label that is empty after mapping'],
+      ['\uFF41'.repeat(64), 'a label of 64 fullwidth letters exceeds 63 octets after mapping'],
+      ['XN--aa---o47jg78q', 'lowercasing does not rescue hyphens in positions 3 and 4'],
+    ])('should reject %j (%s)', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, idnHostnameSchema).valid).toBe(false);
+    });
+
+    it.each([12, 13.7, {}, [], false, null])('should ignore non-string input %j', (data) => {
+      const validator = ZSchema.create();
+      expect(validator.validateSafe(data, { format: 'idn-hostname' }).valid).toBe(true);
+    });
+  });
+
   describe('URI Grammar Source Invariants', () => {
     // The `u` flag is derived from the class bodies rather than passed in. Getting that wrong is
     // silent rather than loud: outside `u` mode a `\u{...}` escape is an identity escape, so the


### PR DESCRIPTION
## Description

Fixes the `email` and `idn-hostname` format validators so the JSON-Schema-Test-Suite bump in #490 goes green. That bump adds 44 new `email` cases and 8 new `idn-hostname` UTS 46 mapping-step cases (upstream [#1112](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/1112)); 7 of them fail against the current validators, producing 116 CI failures across the node + 3 browser projects.

**`email`** — the ASCII format is ASCII-only per RFC 5321/5322, so non-ASCII is now rejected up front. `validator`'s `allow_utf8_local_part` defaults to `true` (and covers quoted pairs), and `isFQDN` accepts non-ASCII domain labels, so no combination of its options gets this right. `require_tld` is also dropped so a single-label domain (`test@io`) validates — `isFQDN` still enforces dot placement, so `test@.iana.org`, `test@iana.org.` and `test@iana..com` remain invalid.

**`idn-hostname`** — `isValidIdnHostname` implemented RFC 5891/5892 U-label validation but had no UTS 46 mapping step at all. Added one, ahead of label splitting: delete `ignored` code points → case-map with `toLowerCase` → compatibility-fold per code point → normalize to NFC. Two details matter:

- The ignored set is the **exact UTS 46 table**, not `\p{Default_Ignorable_Code_Point}`. 3880 Default_Ignorable code points are DISALLOWED rather than ignored, including U+061C ALM, U+200E/200F LRM/RLM and U+202A–202E — deleting those accepts bidi-spoofed hostnames. Both variants score identically on the test suite, so this is pinned by unit tests instead.
- A fold that would introduce **any label separator** is **withheld**, so neither U+2024 ONE DOT LEADER (folding to `.`) nor U+FE12 (folding to U+3002) can forge a label break. A full-Unicode scan bounds the class at 33 non-ASCII code points; all are DISALLOWED or `disallowed_STD3_mapped` except U+FF0E and U+FF61, which `IDN_SEPARATOR_REGEX` already handles.

Processing is nontransitional: the deviations U+00DF, U+03C2, U+200C and U+200D are preserved. The plain `hostname` format is deliberately **not** mapped — `isValidHostname` still rejects every non-ASCII code point, which `hostname.json` requires.

Also fixes two gaps outside the suite: `㍿.com` (U+337F) now maps to its ideograph sequence and validates, and `ﷺ.com` (U+FDFA) is now rejected for folding to a sequence containing spaces.

### Why not `tr46`?

Measured before hand-rolling. Pure `tr46` scores **78/92** on the corpus versus **89/92** today: UTS 46 deliberately marks every CONTEXTO code point the suite tests (`·`, `͵`, `׳`, `״`, `・`, U+302E/302F, U+0640, U+07FA) as `valid` for IDNA2003 compatibility, and `tr46` ships no CONTEXTO implementation — so it cannot replace the validation half at any option setting. Routing plain `hostname` through it costs 18 more tests (58 → 40). It also inlines ~220 KB into both UMD bundles (`deps: { alwaysBundle: [/.*/] }`), +183% on `ZSchema.min.js`, and runs 2.8× slower. The mapping step is the only part it would have fixed, and that part is cheap to write.

## Related issue

Unblocks #490.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] Test improvement

Flagged as breaking in the strict sense: `format: email` now **rejects** non-ASCII addresses it previously accepted (`aé@iana.org`, `a@é.org`), and **accepts** single-label domains it previously rejected (`test@io`). `format: idn-hostname` accepts inputs that UTS 46 maps to valid hostnames. Callers wanting Unicode addresses should use `idn-email`.

## JSON Schema draft(s) affected

- [x] draft-04
- [x] draft-06
- [x] draft-07
- [x] draft-2019-09
- [x] draft-2020-12
- [ ] None / all drafts

`email` affects all five drafts; `idn-hostname` exists from draft-07 onward.

## Checklist

- [x] Branch is based on `main`
- [x] Code follows the project's [conventions](docs/conventions.md)
- [x] `npm run check` passes (lint + format)
- [x] `npm run build` passes
- [x] `npm run build:tests` passes (test type-check)
- [x] `npm test` passes (node + browser)
- [x] New public types/values are exported through `src/index.ts` — n/a, no new public surface
- [x] New features have tests
- [x] `docs/` updated if the public API changed
- [x] JSON Schema Test Suite entries un-excluded if applicable — n/a, none were excluded

## Test plan

`npm test` green: **35,350 passed** across `node`, chromium, firefox and webkit. Verified green against **both** submodule pointers — the new one (9,253 node tests, proving the 7 failures are fixed) and the old one (8,857 node tests, which is what CI on this branch actually runs) — so this merges cleanly ahead of the bump.

Three new table-driven blocks in `test/spec/format-validators.spec.ts` (the file previously had no coverage for these formats at all):

- **`Email Format Validator`** — the 4 newly-fixed cases, plus rows pinning that dropping `require_tld` did not loosen dot placement or the IP-literal fallback.
- **`Hostname Format Validator`** — pins that the mapping step stayed out of `isValidHostname` (`example．com` and `Kelvin.example.com` must stay invalid).
- **`IDN Hostname Format Validator`** — every mapping mechanism on the accept side; on the reject side, the guards that the test suite cannot catch. The four bidi-control rows (U+202E/202A/200E/061C) and the separator-forger rows (U+2024/FE52/2026/FE12) are the only thing that fails if the ignored set is ever "simplified" to `\p{Default_Ignorable_Code_Point}` or the separator guard narrowed.

Correctness was checked against the full merged corpus before implementing (150/150 string cases across the new `idn-hostname.json` and `hostname.json`, up from 147/150; 71/71 on the new `email.json`, up from 67/71, with 27/27 retained on the old one).

### Performance

`applyUts46Mapping` sits on a format-validation hot path. Paired interleaved benchmark against `main` in a single process, median of 15 runs (final state, after the review round below):

| input class | added cost | |
| --- | --- | --- |
| pure lowercase ASCII | 0 ns | **1.00x** |
| U-label (Greek) | +346 ns | 1.26x |
| U-label (Hangul) | +800 ns | 1.26x |
| A-label (`xn--…`) | +512 ns | 1.12x |

Cost is confined to inputs that actually need mapping. A single `charCodeAt` pass classifies the input and returns already-mapped ASCII by identity, so the dominant path is free; because NFKC output is always NFC, one whole-string NFKC check skips both the per-code-point loop and the final recomposition for NFKC-invariant strings. The remaining cost is the `normalize` calls the mapping step fundamentally requires (the regex gates measure ~14 ns each), plus one `normalize('NFC')` per A-label for the RFC 5891 §5.4 check added in review. There is no faster equivalent that is also correct.

### Review round

A read-only review panel ran over this branch. The Codex leg found **four false positives** in the first commit — cases where an *invalid* `idn-hostname` validated, which is the dangerous direction. All four are fixed in `5861996`, each with a reject-side test:

1. **Separator forgery beyond ASCII.** The fold guard only withheld mappings producing an ASCII `.`, so U+FE12 (DISALLOWED) folded to U+3002 and forged a label break — `a<U+FE12>b` validated as two labels. Widened to every label separator. A full-Unicode scan bounds the class at 33 code points; only U+FF0E and U+FF61 are legitimately `mapped`, and `IDN_SEPARATOR_REGEX` already handles both.
2. **U+0345 not mapped.** UTS 46 maps U+0345 to U+03B9 — its mapping column follows NFKC_Casefold, whose case-folding step covers this, while plain NFKC does not. Omitting it left a `Bidi_Class=NSM` mark where an `L` letter belongs, so `<alef>U+0345` passed the RFC 5893 Bidi rule as R+NSM instead of failing as R+L, and it understated label length: 29 × U+1FB3 must expand to a 65-octet A-label but validated. Fixed over NFD so all 63 precomposed code points in U+1F80–U+1FFC are covered by one rule, and applied before the fold since U+1FB3 is NFKC-invariant.
3. **A-label NFC never checked.** RFC 5891 §5.4 requires a decoded U-label to be NFC, but `xn--u-ccb` validated despite decoding to U+0075 U+0308. The mapping step cannot catch this — an A-label is pure ASCII and passes through untouched — so the check belongs at the Punycode decode site.
4. A comment my insertion had separated from the block it describes.

The sonnet and TypeScript legs reported clean; sonnet independently confirmed both original spoofing guards are load-bearing. GitHub Copilot review did not fire on this PR.
## Additional notes

- `test/ZSchemaTestSuite/Issue48.ts` pinned `foo@bar` as **invalid**, directly contradicting the official suite's new "a single-label domain is valid". Updated to `valid: true` with a comment recording why; a `foo@bar..baz` row keeps the negative coverage. Issue #48 was titled "email validation too strict", so this is aligned with its intent.
- `docs/conventions.md` dependency list was stale (claimed "one dependency only" while `dependencies` held three). Corrected, and noted that both UMD targets inline every runtime dep — the constraint that decided the `tr46` question.
- Known limitations of the mapping approximation are recorded in the `hostname.ts` header comment: `disallowed_STD3_valid` code points (e.g. U+00A1 via `xn--7a`) and `\p{No}` dot-formers (e.g. U+2488) are still accepted. The latter is pre-existing and unchanged by this PR.
- **Follow-up:** once this merges, comment `@dependabot rebase` on #490 and the bump should go green unmodified.

_Generated by [Claude Code](https://claude.ai/code)_
